### PR TITLE
epbs block processing

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4824,7 +4824,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let proposal_epoch = proposal_slot.epoch(T::EthSpec::slots_per_epoch());
         if head_state.current_epoch() == proposal_epoch {
             return get_expected_withdrawals(&unadvanced_state, &self.spec)
-                .map(|(withdrawals, _)| withdrawals)
+                .map(|(withdrawals, _, _)| withdrawals)
                 .map_err(Error::PrepareProposerFailed);
         }
 
@@ -4842,7 +4842,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             &self.spec,
         )?;
         get_expected_withdrawals(&advanced_state, &self.spec)
-            .map(|(withdrawals, _)| withdrawals)
+            .map(|(withdrawals, _, _)| withdrawals)
             .map_err(Error::PrepareProposerFailed)
     }
 

--- a/beacon_node/http_api/src/builder_states.rs
+++ b/beacon_node/http_api/src/builder_states.rs
@@ -33,7 +33,7 @@ pub fn get_next_withdrawals<T: BeaconChainTypes>(
     }
 
     match get_expected_withdrawals(&state, &chain.spec) {
-        Ok((withdrawals, _)) => Ok(withdrawals),
+        Ok((withdrawals, _, _)) => Ok(withdrawals),
         Err(e) => Err(warp_utils::reject::custom_server_error(format!(
             "failed to get expected withdrawal: {:?}",
             e

--- a/consensus/state_processing/src/common/get_attestation_participation.rs
+++ b/consensus/state_processing/src/common/get_attestation_participation.rs
@@ -9,6 +9,8 @@ use types::{
 };
 use types::{AttestationData, BeaconState, ChainSpec, EthSpec};
 
+use crate::common::is_attestation_same_slot;
+
 /// Get the participation flags for a valid attestation.
 ///
 /// You should have called `verify_attestation_for_block_inclusion` or similar before
@@ -16,6 +18,7 @@ use types::{AttestationData, BeaconState, ChainSpec, EthSpec};
 ///
 /// This function will return an error if the source of the attestation doesn't match the
 /// state's relevant justified checkpoint.
+/// TODO(EIP7732) the spec calls this a new function, but it is existing function. should we make pr to the spec to fix? https://ethereum.github.io/consensus-specs/specs/_features/eip7732/beacon-chain/#new-get_attestation_participation_flag_indices
 pub fn get_attestation_participation_flag_indices<E: EthSpec>(
     state: &BeaconState<E>,
     data: &AttestationData,
@@ -32,8 +35,31 @@ pub fn get_attestation_participation_flag_indices<E: EthSpec>(
     let is_matching_source = data.source == justified_checkpoint;
     let is_matching_target = is_matching_source
         && data.target.root == *state.get_block_root_at_epoch(data.target.epoch)?;
-    let is_matching_head =
+
+    let is_matching_blockroot =
         is_matching_target && data.beacon_block_root == *state.get_block_root(data.slot)?;
+
+    let is_matching_head = if state.fork_name_unchecked().gloas_enabled() {
+        let is_matching_payload = if is_attestation_same_slot(state, data)? {
+            // For same-slot attestations, data.index must be 0
+            if data.index != 0 {
+                // TODO(EIP7732): consider if we want to use a different error type, since this is more of an overloaded data index scenario as opposed to the InvalidCommitteeIndex previous error. It's more like `AttestationInvalid::BadOverloadedDataIndex`
+                return Err(Error::InvalidCommitteeIndex(data.index));
+            }
+            true
+        } else {
+            // For non same-slot attestations, check execution payload availability
+            // TODO(EIP7732) Discuss if we want to return new error BeaconStateError::InvalidExecutionPayloadAvailabilityIndex here for bit out of bounds or use something like BeaconStateError::InvalidBitfield
+            let slot_index = data.slot.as_usize() % E::slots_per_historical_root();
+            state
+                .execution_payload_availability()?
+                .get(slot_index)
+                .map_err(|_| Error::InvalidExecutionPayloadAvailabilityIndex(slot_index))?
+        };
+        is_matching_blockroot && is_matching_payload
+    } else {
+        is_matching_blockroot
+    };
 
     if !is_matching_source {
         return Err(Error::IncorrectAttestationSource);
@@ -45,6 +71,8 @@ pub fn get_attestation_participation_flag_indices<E: EthSpec>(
         participation_flag_indices.push(TIMELY_SOURCE_FLAG_INDEX);
     }
     if state.fork_name_unchecked().deneb_enabled() {
+        // TODO(EIP7732): gloas spec has is_matching_target and inclusion_delay <= SLOTS_PER_EPOCH check here, but in deneb, we removed the inclusion_delay check. perhaps the spec made a mistake. Could make a pr if think that's the case or clarify with Potuz
+        // https://ethereum.github.io/consensus-specs/specs/_features/eip7732/beacon-chain/#new-get_attestation_participation_flag_indices
         if is_matching_target {
             // [Modified in Deneb:EIP7045]
             participation_flag_indices.push(TIMELY_TARGET_FLAG_INDEX);

--- a/consensus/state_processing/src/common/is_attestation_same_slot.rs
+++ b/consensus/state_processing/src/common/is_attestation_same_slot.rs
@@ -1,0 +1,21 @@
+use types::{AttestationData, BeaconState, BeaconStateError, EthSpec};
+
+/// Checks if the attestation was for the block proposed at the attestation slot.
+///
+/// Returns true if:
+/// - The attestation is for slot 0 (genesis), OR
+/// - The attestation's beacon_block_root matches the block actually proposed at that slot
+///   AND it's different from the previous slot's block (indicating no skip)
+pub fn is_attestation_same_slot<E: EthSpec>(
+    state: &BeaconState<E>,
+    data: &AttestationData,
+) -> Result<bool, BeaconStateError> {
+    if data.slot == 0 {
+        return Ok(true);
+    }
+
+    let is_matching_block_root = data.beacon_block_root == *state.get_block_root(data.slot)?;
+    let is_current_block_root = data.beacon_block_root != *state.get_block_root(data.slot - 1)?;
+
+    Ok(is_matching_block_root && is_current_block_root)
+}

--- a/consensus/state_processing/src/common/mod.rs
+++ b/consensus/state_processing/src/common/mod.rs
@@ -2,6 +2,7 @@ mod deposit_data_tree;
 mod get_attestation_participation;
 mod get_attesting_indices;
 mod initiate_validator_exit;
+mod is_attestation_same_slot;
 mod slash_validator;
 
 pub mod altair;
@@ -14,6 +15,7 @@ pub use get_attesting_indices::{
     attesting_indices_base, attesting_indices_electra, get_attesting_indices_from_state,
 };
 pub use initiate_validator_exit::initiate_validator_exit;
+pub use is_attestation_same_slot::is_attestation_same_slot;
 pub use slash_validator::slash_validator;
 
 use safe_arith::SafeArith;

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -1,8 +1,12 @@
+use self::errors::ExecutionBidInvalid;
 use crate::consensus_context::ConsensusContext;
 use errors::{BlockOperationError, BlockProcessingError, HeaderInvalid};
 use rayon::prelude::*;
 use safe_arith::{ArithError, SafeArith, SafeArithIter};
-use signature_sets::{block_proposal_signature_set, get_pubkey_from_state, randao_signature_set};
+use signature_sets::{
+    block_proposal_signature_set, execution_bid_signature_set, get_pubkey_from_state,
+    randao_signature_set,
+};
 use std::borrow::Cow;
 use tree_hash::TreeHash;
 use types::*;
@@ -171,9 +175,8 @@ pub fn per_block_processing<E: EthSpec, Payload: AbstractExecPayload<E>>(
         let body = block.body();
         if state.fork_name_unchecked().gloas_enabled() {
             process_withdrawals::gloas::process_withdrawals::<E>(state, spec)?;
-
-        // TODO(EIP-7732): build out process_execution_bid
-        // process_execution_bid(state, block, verify_signatures, spec)?;
+            // TODO(EIP-7732) Mark had process_execution_bid above process_randao so need to clarify if makes more sense here or there
+            process_execution_bid(state, block, verify_signatures, spec)?;
         } else {
             process_withdrawals::capella::process_withdrawals::<E, Payload>(
                 state,
@@ -686,4 +689,151 @@ pub fn get_expected_withdrawals<E: EthSpec>(
         processed_builder_withdrawals_count,
         processed_partial_withdrawals_count,
     ))
+}
+
+pub fn process_execution_bid<E: EthSpec, Payload: AbstractExecPayload<E>>(
+    state: &mut BeaconState<E>,
+    block: BeaconBlockRef<'_, E, Payload>,
+    verify_signatures: VerifySignatures,
+    spec: &ChainSpec,
+) -> Result<(), BlockProcessingError> {
+    // Verify the bid signature
+    let signed_bid = block.body().signed_execution_bid()?;
+
+    if verify_signatures.is_true() {
+        block_verify!(
+            execution_bid_signature_set(
+                state,
+                |i| get_pubkey_from_state(state, i),
+                signed_bid,
+                spec
+            )?
+            .verify(),
+            ExecutionBidInvalid::BadSignature.into()
+        );
+    }
+
+    let bid = &signed_bid.message;
+    let builder_index = bid.builder_index;
+    let builder = state.get_validator(builder_index as usize)?;
+
+    // Verify builder is active and not slashed
+    block_verify!(
+        builder.is_active_at(state.current_epoch()),
+        ExecutionBidInvalid::BuilderNotActive(builder_index).into()
+    );
+    block_verify!(
+        !builder.slashed,
+        ExecutionBidInvalid::BuilderSlashed(builder_index).into()
+    );
+
+    let amount = bid.value;
+
+    // For self-builds, amount must be zero regardless of withdrawal credential prefix
+    if builder_index == block.proposer_index() {
+        block_verify!(amount == 0, BlockProcessingError::ExecutionInvalid);
+    } else {
+        // Non-self builds require builder withdrawal credential
+        // TODO(EIP7732): Add proper validation for builder withdrawal credentials via building out helper function has_builder_withdrawal_credential(builder)
+        // https://ethereum.github.io/consensus-specs/specs/_features/eip7732/beacon-chain/#new-has_builder_withdrawal_credential
+    }
+
+    // Check that the builder is active, non-slashed, and has funds to cover the bid
+    let pending_payments = state
+        .builder_pending_payments()?
+        .iter()
+        .filter_map(|payment| {
+            if payment.withdrawal.builder_index == builder_index {
+                Some(payment.withdrawal.amount)
+            } else {
+                None
+            }
+        })
+        .safe_sum()?;
+
+    let pending_withdrawals = state
+        .builder_pending_withdrawals()?
+        .iter()
+        .filter_map(|withdrawal| {
+            if withdrawal.builder_index == builder_index {
+                Some(withdrawal.amount)
+            } else {
+                None
+            }
+        })
+        .safe_sum()?;
+
+    let builder_balance = state.get_balance(builder_index as usize)?;
+
+    block_verify!(
+        amount == 0
+            || builder_balance
+                >= amount
+                    .safe_add(pending_payments)?
+                    .safe_add(pending_withdrawals)?
+                    .safe_add(spec.min_activation_balance)?,
+        ExecutionBidInvalid::InsufficientBalance {
+            builder_index,
+            builder_balance,
+            bid_value: amount,
+        }
+        .into()
+    );
+
+    // Verify that the bid is for the current slot
+    block_verify!(
+        bid.slot == block.slot(),
+        ExecutionBidInvalid::SlotMismatch {
+            state_slot: block.slot(),
+            bid_slot: bid.slot,
+        }
+        .into()
+    );
+
+    // Verify that the bid is for the right parent block
+    let latest_block_hash = state.latest_block_hash()?;
+    block_verify!(
+        bid.parent_block_hash == *latest_block_hash,
+        ExecutionBidInvalid::ParentBlockHashMismatch {
+            state_block_hash: *latest_block_hash,
+            bid_parent_hash: bid.parent_block_hash,
+        }
+        .into()
+    );
+
+    block_verify!(
+        bid.parent_block_root == block.parent_root(),
+        ExecutionBidInvalid::ParentBlockRootMismatch {
+            block_parent_root: block.parent_root(),
+            bid_parent_root: bid.parent_block_root,
+        }
+        .into()
+    );
+
+    // Record the pending payment
+    let pending_payment = BuilderPendingPayment {
+        weight: 0,
+        withdrawal: BuilderPendingWithdrawal {
+            fee_recipient: bid.fee_recipient,
+            amount,
+            builder_index,
+            // TODO(EIP7732): verify if ok to use default here, withdrawable_epoch is not set in the python spec, https://ethereum.github.io/consensus-specs/specs/_features/eip7732/beacon-chain/#new-process_execution_payload_header
+            ..Default::default()
+        },
+    };
+
+    let payment_index =
+        (E::slots_per_epoch() + (bid.slot.as_u64() % E::slots_per_epoch())) as usize;
+
+    *state
+        .builder_pending_payments_mut()?
+        .get_mut(payment_index)
+        .ok_or(BlockProcessingError::BeaconStateError(
+            BeaconStateError::BuilderPendingPaymentsIndexNotSupported(payment_index),
+        ))? = pending_payment;
+
+    // Cache the execution bid
+    *state.latest_execution_bid_mut()? = bid.clone();
+
+    Ok(())
 }

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -30,6 +30,7 @@ pub mod deneb;
 pub mod errors;
 mod is_valid_indexed_attestation;
 pub mod process_operations;
+pub mod process_withdrawals;
 pub mod signature_sets;
 pub mod tests;
 mod verify_attestation;
@@ -39,7 +40,6 @@ mod verify_deposit;
 mod verify_exit;
 mod verify_proposer_slashing;
 
-use crate::common::decrease_balance;
 use crate::common::update_progressive_balances_cache::{
     initialize_progressive_balances_cache, update_progressive_balances_metrics,
 };
@@ -169,13 +169,20 @@ pub fn per_block_processing<E: EthSpec, Payload: AbstractExecPayload<E>>(
     // previous block.
     if is_execution_enabled(state, block.body()) {
         let body = block.body();
-        // TODO(EIP-7732): build out process_withdrawals variant for gloas
-        process_withdrawals::<E, Payload>(state, body.execution_payload()?, spec)?;
-        process_execution_payload::<E, Payload>(state, body, spec)?;
-    }
+        if state.fork_name_unchecked().gloas_enabled() {
+            process_withdrawals::gloas::process_withdrawals::<E>(state, spec)?;
 
-    // TODO(EIP-7732): build out process_execution_bid
-    // process_execution_bid(state, block, verify_signatures, spec)?;
+        // TODO(EIP-7732): build out process_execution_bid
+        // process_execution_bid(state, block, verify_signatures, spec)?;
+        } else {
+            process_withdrawals::capella::process_withdrawals::<E, Payload>(
+                state,
+                body.execution_payload()?,
+                spec,
+            )?;
+            process_execution_payload::<E, Payload>(state, body, spec)?;
+        }
+    }
 
     process_randao(state, block, verify_randao, ctxt, spec)?;
     process_eth1_data(state, block.body().eth1_data())?;
@@ -513,16 +520,66 @@ pub fn compute_timestamp_at_slot<E: EthSpec>(
 
 /// Compute the next batch of withdrawals which should be included in a block.
 ///
-/// https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#new-get_expected_withdrawals
+/// https://ethereum.github.io/consensus-specs/specs/_features/eip7732/beacon-chain/#modified-get_expected_withdrawals
 pub fn get_expected_withdrawals<E: EthSpec>(
     state: &BeaconState<E>,
     spec: &ChainSpec,
-) -> Result<(Withdrawals<E>, Option<usize>), BlockProcessingError> {
+) -> Result<(Withdrawals<E>, Option<usize>, Option<usize>), BlockProcessingError> {
     let epoch = state.current_epoch();
     let mut withdrawal_index = state.next_withdrawal_index()?;
     let mut validator_index = state.next_withdrawal_validator_index()?;
     let mut withdrawals = Vec::<Withdrawal>::with_capacity(E::max_withdrawals_per_payload());
     let fork_name = state.fork_name_unchecked();
+
+    // [New in Gloas:EIP7732]
+    // Sweep for builder payments
+    let processed_builder_withdrawals_count =
+        if let Ok(builder_pending_withdrawals) = state.builder_pending_withdrawals() {
+            let mut processed_builder_withdrawals_count = 0;
+            for withdrawal in builder_pending_withdrawals {
+                if withdrawal.withdrawable_epoch > epoch
+                    || withdrawals.len() + 1 == E::max_withdrawals_per_payload()
+                {
+                    break;
+                }
+
+                if process_withdrawals::is_builder_payment_withdrawable(state, withdrawal)? {
+                    let total_withdrawn = withdrawals
+                        .iter()
+                        .filter_map(|w| {
+                            (w.validator_index == withdrawal.builder_index).then_some(w.amount)
+                        })
+                        .safe_sum()?;
+                    let balance = state
+                        .get_balance(withdrawal.builder_index as usize)?
+                        .safe_sub(total_withdrawn)?;
+                    let builder = state.get_validator(withdrawal.builder_index as usize)?;
+
+                    let withdrawable_balance = if builder.slashed {
+                        std::cmp::min(balance, withdrawal.amount)
+                    } else if balance > spec.min_activation_balance {
+                        std::cmp::min(
+                            balance.safe_sub(spec.min_activation_balance)?,
+                            withdrawal.amount,
+                        )
+                    } else {
+                        0
+                    };
+
+                    withdrawals.push(Withdrawal {
+                        index: withdrawal_index,
+                        validator_index: withdrawal.builder_index,
+                        address: withdrawal.fee_recipient,
+                        amount: withdrawable_balance,
+                    });
+                    withdrawal_index.safe_add_assign(1)?;
+                }
+                processed_builder_withdrawals_count.safe_add_assign(1)?;
+            }
+            Some(processed_builder_withdrawals_count)
+        } else {
+            None
+        };
 
     // [New in Electra:EIP7251]
     // Consume pending partial withdrawals
@@ -624,71 +681,9 @@ pub fn get_expected_withdrawals<E: EthSpec>(
             .safe_rem(state.validators().len() as u64)?;
     }
 
-    Ok((withdrawals.into(), processed_partial_withdrawals_count))
-}
-
-/// Apply withdrawals to the state.
-/// TODO(EIP-7732): abstract this out and create gloas variant
-pub fn process_withdrawals<E: EthSpec, Payload: AbstractExecPayload<E>>(
-    state: &mut BeaconState<E>,
-    payload: Payload::Ref<'_>,
-    spec: &ChainSpec,
-) -> Result<(), BlockProcessingError> {
-    if state.fork_name_unchecked().capella_enabled() {
-        let (expected_withdrawals, processed_partial_withdrawals_count) =
-            get_expected_withdrawals(state, spec)?;
-        let expected_root = expected_withdrawals.tree_hash_root();
-        let withdrawals_root = payload.withdrawals_root()?;
-
-        if expected_root != withdrawals_root {
-            return Err(BlockProcessingError::WithdrawalsRootMismatch {
-                expected: expected_root,
-                found: withdrawals_root,
-            });
-        }
-
-        for withdrawal in expected_withdrawals.iter() {
-            decrease_balance(
-                state,
-                withdrawal.validator_index as usize,
-                withdrawal.amount,
-            )?;
-        }
-
-        // Update pending partial withdrawals [New in Electra:EIP7251]
-        if let Some(processed_partial_withdrawals_count) = processed_partial_withdrawals_count {
-            state
-                .pending_partial_withdrawals_mut()?
-                .pop_front(processed_partial_withdrawals_count)?;
-        }
-
-        // Update the next withdrawal index if this block contained withdrawals
-        if let Some(latest_withdrawal) = expected_withdrawals.last() {
-            *state.next_withdrawal_index_mut()? = latest_withdrawal.index.safe_add(1)?;
-
-            // Update the next validator index to start the next withdrawal sweep
-            if expected_withdrawals.len() == E::max_withdrawals_per_payload() {
-                // Next sweep starts after the latest withdrawal's validator index
-                let next_validator_index = latest_withdrawal
-                    .validator_index
-                    .safe_add(1)?
-                    .safe_rem(state.validators().len() as u64)?;
-                *state.next_withdrawal_validator_index_mut()? = next_validator_index;
-            }
-        }
-
-        // Advance sweep by the max length of the sweep if there was not a full set of withdrawals
-        if expected_withdrawals.len() != E::max_withdrawals_per_payload() {
-            let next_validator_index = state
-                .next_withdrawal_validator_index()?
-                .safe_add(spec.max_validators_per_withdrawals_sweep)?
-                .safe_rem(state.validators().len() as u64)?;
-            *state.next_withdrawal_validator_index_mut()? = next_validator_index;
-        }
-
-        Ok(())
-    } else {
-        // these shouldn't even be encountered but they're here for completeness
-        Ok(())
-    }
+    Ok((
+        withdrawals.into(),
+        processed_builder_withdrawals_count,
+        processed_partial_withdrawals_count,
+    ))
 }

--- a/consensus/state_processing/src/per_block_processing/errors.rs
+++ b/consensus/state_processing/src/per_block_processing/errors.rs
@@ -340,7 +340,10 @@ pub enum AttestationInvalid {
         attestation: Slot,
     },
     /// Attestation slot is too far in the past to be included in a block.
-    IncludedTooLate { state: Slot, attestation: Slot },
+    IncludedTooLate {
+        state: Slot,
+        attestation: Slot,
+    },
     /// Attestation target epoch does not match attestation slot.
     TargetEpochSlotMismatch {
         target_epoch: Epoch,
@@ -373,6 +376,7 @@ pub enum AttestationInvalid {
     BadSignature,
     /// The indexed attestation created from this attestation was found to be invalid.
     BadIndexedAttestation(IndexedAttestationInvalid),
+    BadOverloadedDataIndex,
 }
 
 impl From<BlockOperationError<IndexedAttestationInvalid>>

--- a/consensus/state_processing/src/per_block_processing/errors.rs
+++ b/consensus/state_processing/src/per_block_processing/errors.rs
@@ -91,6 +91,9 @@ pub enum BlockProcessingError {
     },
     WithdrawalCredentialsInvalid,
     PendingAttestationInElectra,
+    ExecutionBidInvalid {
+        reason: ExecutionBidInvalid,
+    },
 }
 
 impl From<BeaconStateError> for BlockProcessingError {
@@ -144,6 +147,12 @@ impl From<EpochCacheError> for BlockProcessingError {
 impl From<milhouse::Error> for BlockProcessingError {
     fn from(e: milhouse::Error) -> Self {
         Self::MilhouseError(e)
+    }
+}
+
+impl From<ExecutionBidInvalid> for BlockProcessingError {
+    fn from(reason: ExecutionBidInvalid) -> Self {
+        Self::ExecutionBidInvalid { reason }
     }
 }
 
@@ -438,6 +447,34 @@ pub enum ExitInvalid {
     /// been invalid or an internal error occurred.
     SignatureSetError(SignatureSetError),
     PendingWithdrawalInQueue(u64),
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum ExecutionBidInvalid {
+    /// The signature is invalid.
+    BadSignature,
+    /// The builder is not an active validator.
+    BuilderNotActive(u64),
+    /// The builder is slashed
+    BuilderSlashed(u64),
+    /// The builder has insufficient balance to cover the bid
+    InsufficientBalance {
+        builder_index: u64,
+        builder_balance: u64,
+        bid_value: u64,
+    },
+    /// Bid slot doesn't match state slot
+    SlotMismatch { state_slot: Slot, bid_slot: Slot },
+    /// The bid's parent block hash doesn't match the state's latest block hash
+    ParentBlockHashMismatch {
+        state_block_hash: ExecutionBlockHash,
+        bid_parent_hash: ExecutionBlockHash,
+    },
+    /// The bid's parent block root doesn't match the block's parent root
+    ParentBlockRootMismatch {
+        block_parent_root: Hash256,
+        bid_parent_root: Hash256,
+    },
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -1,10 +1,11 @@
 use super::*;
 use crate::common::{
     get_attestation_participation_flag_indices, increase_balance, initiate_validator_exit,
-    slash_validator,
+    is_attestation_same_slot, slash_validator,
 };
 use crate::per_block_processing::errors::{BlockProcessingError, IntoWithIndex};
 use crate::VerifySignatures;
+use safe_arith::ArithError;
 use types::consts::altair::{PARTICIPATION_FLAG_WEIGHTS, PROPOSER_WEIGHT, WEIGHT_DENOMINATOR};
 use types::typenum::U33;
 
@@ -166,11 +167,25 @@ pub mod altair_deneb {
 
         // Update epoch participation flags.
         let mut proposer_reward_numerator = 0;
+
+        // Track validators for Gloas pending builder payment logic
+        let mut validators_setting_new_flags_effective_balances =
+            if state.fork_name_unchecked().gloas_enabled() {
+                // TODO(EIP7732): Discuss if want to set capacity to full list of attesters from the attestation
+                Some(Vec::with_capacity(indexed_att.attesting_indices_len()))
+            } else {
+                None
+            };
+
         for index in indexed_att.attesting_indices_iter() {
             let index = *index as usize;
-
             let validator_effective_balance = state.epoch_cache().get_effective_balance(index)?;
             let validator_slashed = state.slashings_cache().is_slashed(index);
+
+            // [New in EIP7732]
+            // For same-slot attestations, check if we're setting any new flags
+            // If we are, this validator hasn't contributed to this slot's quorum yet
+            let mut will_set_new_flag = false;
 
             for (flag_index, &weight) in PARTICIPATION_FLAG_WEIGHTS.iter().enumerate() {
                 let epoch_participation = state.get_epoch_participation_mut(
@@ -196,7 +211,20 @@ pub mod altair_deneb {
                             validator_effective_balance,
                             validator_slashed,
                         )?;
+
+                        will_set_new_flag = true;
                     }
+                }
+            }
+
+            // Collect validators for Gloas builder payment processing
+            if let Some(ref mut effective_balances) =
+                validators_setting_new_flags_effective_balances
+            {
+                // We will only add weight for same-slot attestations when any new flag is set
+                // This ensures each validator contributes exactly once per slot
+                if will_set_new_flag && is_attestation_same_slot(state, data)? {
+                    effective_balances.push(validator_effective_balance);
                 }
             }
         }
@@ -207,6 +235,38 @@ pub mod altair_deneb {
             .safe_div(PROPOSER_WEIGHT)?;
         let proposer_reward = proposer_reward_numerator.safe_div(proposer_reward_denominator)?;
         increase_balance(state, proposer_index as usize, proposer_reward)?;
+
+        // [New in EIP-7732] Process builder payments
+        if let Some(effective_balances) = validators_setting_new_flags_effective_balances {
+            process_builder_payments_for_attestation(state, effective_balances, data, spec)?;
+        }
+
+        Ok(())
+    }
+
+    /// Process builder payments for validators who set new participation flags in Gloas fork
+    fn process_builder_payments_for_attestation<E: EthSpec>(
+        state: &mut BeaconState<E>,
+        effective_balances: Vec<u64>,
+        data: &AttestationData,
+        _spec: &ChainSpec,
+    ) -> Result<(), BlockProcessingError> {
+        let current_epoch_target = data.target.epoch == state.current_epoch();
+        let payment_index = if current_epoch_target {
+            E::slots_per_epoch() + data.slot.as_u64() % E::slots_per_epoch()
+        } else {
+            data.slot.as_u64() % E::slots_per_epoch()
+        };
+
+        if let Ok(builder_payments) = state.builder_pending_payments_mut() {
+            if let Some(payment) = builder_payments.get_mut(payment_index as usize) {
+                effective_balances.iter().try_for_each(|&balance| {
+                    payment.weight = payment.weight.safe_add(balance)?;
+                    Ok::<(), ArithError>(())
+                })?;
+            }
+        }
+
         Ok(())
     }
 }

--- a/consensus/state_processing/src/per_block_processing/process_withdrawals.rs
+++ b/consensus/state_processing/src/per_block_processing/process_withdrawals.rs
@@ -1,0 +1,153 @@
+use super::errors::BlockProcessingError;
+use super::get_expected_withdrawals;
+use crate::common::decrease_balance;
+use safe_arith::SafeArith;
+use tree_hash::TreeHash;
+use types::{
+    AbstractExecPayload, BeaconState, BuilderPendingWithdrawal, ChainSpec, EthSpec, ExecPayload,
+    List, Withdrawals,
+};
+
+/// Check if a builder payment is withdrawable.
+/// A builder payment is withdrawable if the builder is not slashed or
+/// the builder's withdrawable epoch has been reached.
+pub fn is_builder_payment_withdrawable<E: EthSpec>(
+    state: &BeaconState<E>,
+    withdrawal: &BuilderPendingWithdrawal,
+) -> Result<bool, BlockProcessingError> {
+    let builder = state.get_validator(withdrawal.builder_index as usize)?;
+    let current_epoch = state.current_epoch();
+
+    Ok(builder.withdrawable_epoch >= current_epoch || !builder.slashed)
+}
+
+fn process_withdrawals_common<E: EthSpec>(
+    state: &mut BeaconState<E>,
+    expected_withdrawals: Withdrawals<E>,
+    partial_withdrawals_count: Option<usize>,
+    spec: &ChainSpec,
+) -> Result<(), BlockProcessingError> {
+    match state {
+        BeaconState::Capella(_)
+        | BeaconState::Deneb(_)
+        | BeaconState::Electra(_)
+        | BeaconState::Fulu(_)
+        | BeaconState::Gloas(_) => {
+            // Update pending partial withdrawals [New in Electra:EIP7251]
+            if let Some(partial_withdrawals_count) = partial_withdrawals_count {
+                state
+                    .pending_partial_withdrawals_mut()?
+                    .pop_front(partial_withdrawals_count)?;
+            }
+
+            // Update the next withdrawal index if this block contained withdrawals
+            if let Some(latest_withdrawal) = expected_withdrawals.last() {
+                *state.next_withdrawal_index_mut()? = latest_withdrawal.index.safe_add(1)?;
+
+                // Update the next validator index to start the next withdrawal sweep
+                if expected_withdrawals.len() == E::max_withdrawals_per_payload() {
+                    // Next sweep starts after the latest withdrawal's validator index
+                    let next_validator_index = latest_withdrawal
+                        .validator_index
+                        .safe_add(1)?
+                        .safe_rem(state.validators().len() as u64)?;
+                    *state.next_withdrawal_validator_index_mut()? = next_validator_index;
+                }
+            }
+
+            // Advance sweep by the max length of the sweep if there was not a full set of withdrawals
+            if expected_withdrawals.len() != E::max_withdrawals_per_payload() {
+                let next_validator_index = state
+                    .next_withdrawal_validator_index()?
+                    .safe_add(spec.max_validators_per_withdrawals_sweep)?
+                    .safe_rem(state.validators().len() as u64)?;
+                *state.next_withdrawal_validator_index_mut()? = next_validator_index;
+            }
+
+            Ok(())
+        }
+        // these shouldn't even be encountered but they're here for completeness
+        BeaconState::Base(_) | BeaconState::Altair(_) | BeaconState::Bellatrix(_) => Ok(()),
+    }
+}
+
+pub mod capella {
+    use super::*;
+    /// Apply withdrawals to the state.
+    pub fn process_withdrawals<E: EthSpec, Payload: AbstractExecPayload<E>>(
+        state: &mut BeaconState<E>,
+        payload: Payload::Ref<'_>,
+        spec: &ChainSpec,
+    ) -> Result<(), BlockProcessingError> {
+        let (expected_withdrawals, _, partial_withdrawals_count) =
+            get_expected_withdrawals(state, spec)?;
+
+        let expected_root = expected_withdrawals.tree_hash_root();
+        let withdrawals_root = payload.withdrawals_root()?;
+        if expected_root != withdrawals_root {
+            return Err(BlockProcessingError::WithdrawalsRootMismatch {
+                expected: expected_root,
+                found: withdrawals_root,
+            });
+        }
+
+        for withdrawal in expected_withdrawals.iter() {
+            decrease_balance(
+                state,
+                withdrawal.validator_index as usize,
+                withdrawal.amount,
+            )?;
+        }
+
+        process_withdrawals_common(state, expected_withdrawals, partial_withdrawals_count, spec)
+    }
+}
+
+pub mod gloas {
+    use super::*;
+    /// Apply withdrawals to the state.
+    pub fn process_withdrawals<E: EthSpec>(
+        state: &mut BeaconState<E>,
+        spec: &ChainSpec,
+    ) -> Result<(), BlockProcessingError> {
+        if !state.is_parent_block_full() {
+            return Ok(());
+        }
+
+        let (expected_withdrawals, builder_withdrawals_count, partial_withdrawals_count) =
+            get_expected_withdrawals(state, spec)?;
+
+        *state.latest_withdrawals_root_mut()? = expected_withdrawals.tree_hash_root();
+
+        for withdrawal in expected_withdrawals.iter() {
+            decrease_balance(
+                state,
+                withdrawal.validator_index as usize,
+                withdrawal.amount,
+            )?;
+        }
+
+        if let (Ok(builder_pending_withdrawals), Some(builder_count)) = (
+            state.builder_pending_withdrawals(),
+            builder_withdrawals_count,
+        ) {
+            let mut updated_builder_withdrawals = Vec::new();
+
+            for (i, withdrawal) in builder_pending_withdrawals.iter().enumerate() {
+                if i < builder_count {
+                    if !is_builder_payment_withdrawable(state, withdrawal)? {
+                        updated_builder_withdrawals.push(withdrawal.clone());
+                    }
+                } else {
+                    updated_builder_withdrawals.push(withdrawal.clone());
+                }
+            }
+
+            *state.builder_pending_withdrawals_mut()? = List::new(updated_builder_withdrawals)?;
+        }
+
+        process_withdrawals_common(state, expected_withdrawals, partial_withdrawals_count, spec)?;
+
+        Ok(())
+    }
+}

--- a/consensus/state_processing/src/per_block_processing/signature_sets.rs
+++ b/consensus/state_processing/src/per_block_processing/signature_sets.rs
@@ -11,8 +11,8 @@ use types::{
     BeaconStateError, ChainSpec, DepositData, Domain, Epoch, EthSpec, Fork, Hash256,
     InconsistentFork, IndexedAttestation, IndexedAttestationRef, ProposerSlashing, PublicKey,
     PublicKeyBytes, Signature, SignedAggregateAndProof, SignedBeaconBlock, SignedBeaconBlockHeader,
-    SignedBlsToExecutionChange, SignedContributionAndProof, SignedRoot, SignedVoluntaryExit,
-    SigningData, Slot, SyncAggregate, SyncAggregatorSelectionData, Unsigned,
+    SignedBlsToExecutionChange, SignedContributionAndProof, SignedExecutionBid, SignedRoot,
+    SignedVoluntaryExit, SigningData, Slot, SyncAggregate, SyncAggregatorSelectionData, Unsigned,
 };
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -329,6 +329,34 @@ where
     let message = indexed_attestation.data().signing_root(domain);
 
     Ok(SignatureSet::multiple_pubkeys(signature, pubkeys, message))
+}
+
+pub fn execution_bid_signature_set<'a, E, F>(
+    state: &'a BeaconState<E>,
+    get_pubkey: F,
+    signed_execution_bid: &'a SignedExecutionBid,
+    spec: &'a ChainSpec,
+) -> Result<SignatureSet<'a>>
+where
+    E: EthSpec,
+    F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
+{
+    let domain = spec.get_domain(
+        state.current_epoch(),
+        Domain::BeaconBuilder,
+        &state.fork(),
+        state.genesis_validators_root(),
+    );
+    let execution_bid = &signed_execution_bid.message;
+    let pubkey = get_pubkey(execution_bid.builder_index as usize)
+        .ok_or(Error::ValidatorUnknown(execution_bid.builder_index))?;
+    let message = execution_bid.signing_root(domain);
+
+    Ok(SignatureSet::single_pubkey(
+        &signed_execution_bid.signature,
+        pubkey,
+        message,
+    ))
 }
 
 /// Returns the signature set for the given `attester_slashing` and corresponding `pubkeys`.

--- a/consensus/state_processing/src/per_block_processing/verify_attestation.rs
+++ b/consensus/state_processing/src/per_block_processing/verify_attestation.rs
@@ -63,18 +63,23 @@ pub fn verify_attestation_for_state<'ctxt, E: EthSpec>(
 ) -> Result<IndexedAttestationRef<'ctxt, E>> {
     let data = attestation.data();
 
-    // NOTE: choosing a validation based on the attestation's fork
-    // rather than the state's fork makes this simple, but technically the spec
-    // defines this verification based on the state's fork.
-    match attestation {
-        AttestationRef::Base(_) => {
+    // TODO(EIP7732): modifying this to verify data.index based on fork as opposed to Attestation variant since we haven't modified Attestation superstruct since Electra. just checking if this is ok
+    match state.fork_name_unchecked() {
+        ForkName::Base
+        | ForkName::Altair
+        | ForkName::Bellatrix
+        | ForkName::Capella
+        | ForkName::Deneb => {
             verify!(
                 data.index < state.get_committee_count_at_slot(data.slot)?,
                 Invalid::BadCommitteeIndex
             );
         }
-        AttestationRef::Electra(_) => {
+        ForkName::Electra | ForkName::Fulu => {
             verify!(data.index == 0, Invalid::BadCommitteeIndex);
+        }
+        ForkName::Gloas => {
+            verify!(data.index < 2, Invalid::BadOverloadedDataIndex);
         }
     }
 

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -174,6 +174,7 @@ pub enum Error {
         aggregator_index: u64,
     },
     PleaseNotifyTheDevs(String),
+    InvalidExecutionPayloadAvailabilityIndex(usize),
 }
 
 /// Control whether an epoch-indexed field can be indexed at the next epoch or not.

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -160,6 +160,7 @@ pub enum Error {
     TotalActiveBalanceDiffUninitialized,
     GeneralizedIndexNotSupported(usize),
     IndexNotSupported(usize),
+    BuilderPendingPaymentsIndexNotSupported(usize),
     InvalidFlagIndex(usize),
     MerkleTreeError(merkle_proof::MerkleTreeError),
     PartialWithdrawalCountInvalid(usize),

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -749,6 +749,21 @@ impl<E: EthSpec> BeaconState<E> {
         }
     }
 
+    /// Return true if the parent block was full (both beacon block and execution payload were present).
+    pub fn is_parent_block_full(&self) -> bool {
+        match self {
+            BeaconState::Base(_) | BeaconState::Altair(_) => false,
+            BeaconState::Bellatrix(_)
+            | BeaconState::Capella(_)
+            | BeaconState::Deneb(_)
+            | BeaconState::Electra(_)
+            | BeaconState::Fulu(_) => true,
+            BeaconState::Gloas(state) => {
+                state.latest_execution_bid.block_hash == state.latest_block_hash
+            }
+        }
+    }
+
     /// Returns the `tree_hash_root` of the state.
     pub fn canonical_root(&mut self) -> Result<Hash256, Error> {
         self.update_tree_hash_cache()
@@ -2124,20 +2139,6 @@ impl<E: EthSpec> BeaconState<E> {
             RelativeEpoch::Previous => 0,
             RelativeEpoch::Current => 1,
             RelativeEpoch::Next => 2,
-        }
-    }
-
-    pub fn is_parent_block_full(&self) -> bool {
-        match self {
-            BeaconState::Base(_) | BeaconState::Altair(_) => false,
-            BeaconState::Bellatrix(_)
-            | BeaconState::Capella(_)
-            | BeaconState::Deneb(_)
-            | BeaconState::Electra(_)
-            | BeaconState::Fulu(_) => true,
-            BeaconState::Gloas(state) => {
-                state.latest_execution_bid.block_hash == state.latest_block_hash
-            }
         }
     }
 

--- a/testing/ef_tests/src/cases/operations.rs
+++ b/testing/ef_tests/src/cases/operations.rs
@@ -413,8 +413,15 @@ impl<E: EthSpec> Operation<E> for WithdrawalsPayload<E> {
         spec: &ChainSpec,
         _: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
-        // TODO(EIP-7732): implement separate gloas and non-gloas variants of process_withdrawals
-        process_withdrawals::<_, FullPayload<_>>(state, self.payload.to_ref(), spec)
+        if state.fork_name_unchecked().gloas_enabled() {
+            process_withdrawals::gloas::process_withdrawals(state, spec)
+        } else {
+            process_withdrawals::capella::process_withdrawals::<_, FullPayload<_>>(
+                state,
+                self.payload.to_ref(),
+                spec,
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Changes to `per_block_processing` per [spec](https://ethereum.github.io/consensus-specs/specs/_features/eip7732/beacon-chain/)
- `process_withdrawals` modified
  -  `is_parent_block_full` added
  -  `get_expected_withdrawals` modified 
    -  `is_builder_payment_withdrawable` added
 - `process_execution_bid` added
   - built the `verify_execution_payload_header_signature` logic into  `process_execution_bid` like in Mark's implementation
- `process_attestations` modified
  - `is_attestation_same_slot` added
  -  `get_attestation_participation_flag_indices` modified

Note:
- it's probably easiest to review this PR by going through the commits individually since they're mutually exclusive changes for each one
- most of the `process_withdrawals` logic was ported over from the old epbs [branch](https://github.com/sigp/lighthouse/tree/eip-7732) with some small changes due to spec changes since then.  The more significant additions I made were read/write updates to incorporate `BeaconState::builder_pending_withdrawals` into `process_withdrawals` and `get_expected_withdrawals`
- [cheatsheet](https://hackmd.io/2C9lEE0mQQaBskc_hmoH8w?view) for how builder bids are processed under epbs

The code compiles 🥳 