### PR TITLE
Epbs process epoch

### DIFF
--- a/consensus/state_processing/src/per_epoch_processing.rs
+++ b/consensus/state_processing/src/per_epoch_processing.rs
@@ -18,6 +18,7 @@ pub mod capella;
 pub mod effective_balance_updates;
 pub mod epoch_processing_summary;
 pub mod errors;
+pub mod gloas;
 pub mod historical_roots_update;
 pub mod justification_and_finalization_state;
 pub mod registry_updates;

--- a/consensus/state_processing/src/per_epoch_processing/altair.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair.rs
@@ -6,13 +6,13 @@ use crate::epoch_cache::initialize_epoch_cache;
 use crate::per_epoch_processing::single_pass::{SinglePassConfig, process_epoch_single_pass};
 use crate::per_epoch_processing::{
     capella::process_historical_summaries_update,
+    gloas::process_builder_pending_payments,
     historical_roots_update::process_historical_roots_update,
     resets::{process_eth1_data_reset, process_randao_mixes_reset, process_slashings_reset},
 };
 pub use inactivity_updates::process_inactivity_updates_slow;
 pub use justification_and_finalization::process_justification_and_finalization;
 pub use participation_flag_updates::process_participation_flag_updates;
-pub use process_builder_pending_payments::process_builder_pending_payments;
 pub use rewards_and_penalties::process_rewards_and_penalties_slow;
 pub use sync_committee_updates::process_sync_committee_updates;
 use types::{BeaconState, ChainSpec, EthSpec, RelativeEpoch};
@@ -20,7 +20,6 @@ use types::{BeaconState, ChainSpec, EthSpec, RelativeEpoch};
 pub mod inactivity_updates;
 pub mod justification_and_finalization;
 pub mod participation_flag_updates;
-pub mod process_builder_pending_payments;
 pub mod rewards_and_penalties;
 pub mod sync_committee_updates;
 
@@ -79,7 +78,8 @@ pub fn process_epoch<E: EthSpec>(
 
     process_sync_committee_updates(state, spec)?;
 
-    if state.fork_name_unchecked().gloas_enabled() {
+    if state.builder_pending_payments().is_ok() {
+        // Post-Gloas
         process_builder_pending_payments(state, spec)?;
     }
 

--- a/consensus/state_processing/src/per_epoch_processing/altair.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair.rs
@@ -12,6 +12,7 @@ use crate::per_epoch_processing::{
 pub use inactivity_updates::process_inactivity_updates_slow;
 pub use justification_and_finalization::process_justification_and_finalization;
 pub use participation_flag_updates::process_participation_flag_updates;
+pub use process_builder_pending_payments::process_builder_pending_payments;
 pub use rewards_and_penalties::process_rewards_and_penalties_slow;
 pub use sync_committee_updates::process_sync_committee_updates;
 use types::{BeaconState, ChainSpec, EthSpec, RelativeEpoch};
@@ -19,6 +20,7 @@ use types::{BeaconState, ChainSpec, EthSpec, RelativeEpoch};
 pub mod inactivity_updates;
 pub mod justification_and_finalization;
 pub mod participation_flag_updates;
+pub mod process_builder_pending_payments;
 pub mod rewards_and_penalties;
 pub mod sync_committee_updates;
 
@@ -76,6 +78,10 @@ pub fn process_epoch<E: EthSpec>(
     process_participation_flag_updates(state)?;
 
     process_sync_committee_updates(state, spec)?;
+
+    if state.fork_name_unchecked().gloas_enabled() {
+        process_builder_pending_payments(state, spec)?;
+    }
 
     // Rotate the epoch caches to suit the epoch transition.
     state.advance_caches()?;

--- a/consensus/state_processing/src/per_epoch_processing/altair/process_builder_pending_payments.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair/process_builder_pending_payments.rs
@@ -1,0 +1,62 @@
+use super::Error;
+use safe_arith::SafeArith;
+use types::{BeaconState, BuilderPendingPayment, ChainSpec, EthSpec, Vector};
+
+pub fn process_builder_pending_payments<E: EthSpec>(
+    state: &mut BeaconState<E>,
+    spec: &ChainSpec,
+) -> Result<(), Error> {
+    let quorum = get_builder_payment_quorum_threshold(state, spec)?;
+
+    // Collect qualifying payments
+    let qualifying_payments = state
+        .builder_pending_payments()?
+        .iter()
+        .take(E::slots_per_epoch() as usize)
+        .filter(|payment| payment.weight > quorum)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    // Update `builder_pending_withdrawals` with qualifying `builder_pending_payments`
+    qualifying_payments
+        .into_iter()
+        .try_for_each(|payment| -> Result<(), Error> {
+            let exit_queue_epoch =
+                state.compute_exit_epoch_and_update_churn(payment.withdrawal.amount, spec)?;
+            let withdrawable_epoch =
+                exit_queue_epoch.safe_add(spec.min_validator_withdrawability_delay)?;
+
+            let mut withdrawal = payment.withdrawal.clone();
+            withdrawal.withdrawable_epoch = withdrawable_epoch;
+            state.builder_pending_withdrawals_mut()?.push(withdrawal)?;
+            Ok(())
+        })?;
+
+    // Move remaining `builder_pending_payments` to start of list and set the rest to default
+    let new_payments = state
+        .builder_pending_payments()?
+        .iter()
+        .skip(E::slots_per_epoch() as usize)
+        .cloned()
+        .chain((0..E::slots_per_epoch() as usize).map(|_| BuilderPendingPayment::default()))
+        .collect::<Vec<_>>();
+
+    *state.builder_pending_payments_mut()? = Vector::new(new_payments)?;
+
+    Ok(())
+}
+
+pub fn get_builder_payment_quorum_threshold<E: EthSpec>(
+    state: &BeaconState<E>,
+    spec: &ChainSpec,
+) -> Result<u64, Error> {
+    let total_active_balance = state.get_total_active_balance()?;
+
+    let quorum = total_active_balance
+        .safe_div(E::slots_per_epoch())?
+        .safe_mul(spec.builder_payment_threshold_numerator)?;
+
+    quorum
+        .safe_div(spec.builder_payment_threshold_denominator)
+        .map_err(Error::from)
+}

--- a/consensus/state_processing/src/per_epoch_processing/gloas.rs
+++ b/consensus/state_processing/src/per_epoch_processing/gloas.rs
@@ -1,0 +1,3 @@
+pub use process_builder_pending_payments::process_builder_pending_payments;
+
+mod process_builder_pending_payments;

--- a/consensus/state_processing/src/per_epoch_processing/gloas/process_builder_pending_payments.rs
+++ b/consensus/state_processing/src/per_epoch_processing/gloas/process_builder_pending_payments.rs
@@ -1,11 +1,13 @@
-use super::Error;
+use crate::EpochProcessingError;
 use safe_arith::SafeArith;
 use types::{BeaconState, BuilderPendingPayment, ChainSpec, EthSpec, Vector};
 
+/// TODO(EIP-7732): Add EF consensus-spec tests for `process_builder_pending_payments`
+/// Currently blocked by EF consensus-spec-tests for Gloas not yet integrated.
 pub fn process_builder_pending_payments<E: EthSpec>(
     state: &mut BeaconState<E>,
     spec: &ChainSpec,
-) -> Result<(), Error> {
+) -> Result<(), EpochProcessingError> {
     let quorum = get_builder_payment_quorum_threshold(state, spec)?;
 
     // Collect qualifying payments
@@ -18,9 +20,8 @@ pub fn process_builder_pending_payments<E: EthSpec>(
         .collect::<Vec<_>>();
 
     // Update `builder_pending_withdrawals` with qualifying `builder_pending_payments`
-    qualifying_payments
-        .into_iter()
-        .try_for_each(|payment| -> Result<(), Error> {
+    qualifying_payments.into_iter().try_for_each(
+        |payment| -> Result<(), EpochProcessingError> {
             let exit_queue_epoch =
                 state.compute_exit_epoch_and_update_churn(payment.withdrawal.amount, spec)?;
             let withdrawable_epoch =
@@ -30,7 +31,8 @@ pub fn process_builder_pending_payments<E: EthSpec>(
             withdrawal.withdrawable_epoch = withdrawable_epoch;
             state.builder_pending_withdrawals_mut()?.push(withdrawal)?;
             Ok(())
-        })?;
+        },
+    )?;
 
     // Move remaining `builder_pending_payments` to start of list and set the rest to default
     let new_payments = state
@@ -49,7 +51,7 @@ pub fn process_builder_pending_payments<E: EthSpec>(
 pub fn get_builder_payment_quorum_threshold<E: EthSpec>(
     state: &BeaconState<E>,
     spec: &ChainSpec,
-) -> Result<u64, Error> {
+) -> Result<u64, EpochProcessingError> {
     let total_active_balance = state.get_total_active_balance()?;
 
     let quorum = total_active_balance
@@ -58,5 +60,5 @@ pub fn get_builder_payment_quorum_threshold<E: EthSpec>(
 
     quorum
         .safe_div(spec.builder_payment_threshold_denominator)
-        .map_err(Error::from)
+        .map_err(EpochProcessingError::from)
 }

--- a/consensus/state_processing/src/per_slot_processing.rs
+++ b/consensus/state_processing/src/per_slot_processing.rs
@@ -13,11 +13,18 @@ pub enum Error {
     EpochProcessingError(EpochProcessingError),
     ArithError(ArithError),
     InconsistentStateFork(InconsistentFork),
+    BitfieldError(ssz::BitfieldError),
 }
 
 impl From<ArithError> for Error {
     fn from(e: ArithError) -> Self {
         Self::ArithError(e)
+    }
+}
+
+impl From<ssz::BitfieldError> for Error {
+    fn from(e: ssz::BitfieldError) -> Self {
+        Self::BitfieldError(e)
     }
 }
 
@@ -48,6 +55,18 @@ pub fn per_slot_processing<E: EthSpec>(
     };
 
     state.slot_mut().safe_add_assign(1)?;
+
+    // Unset the next payload availability
+    if state.fork_name_unchecked().gloas_enabled() {
+        let next_slot_index = state
+            .slot()
+            .as_usize()
+            .safe_add(1)?
+            .safe_rem(E::slots_per_historical_root())?;
+        state
+            .execution_payload_availability_mut()?
+            .set(next_slot_index, false)?;
+    }
 
     // Process fork upgrades here. Note that multiple upgrades can potentially run
     // in sequence if they are scheduled in the same Epoch (common in testnets)


### PR DESCRIPTION
## Changes per [spec](https://ethereum.github.io/consensus-specs/specs/gloas/beacon-chain/#epoch-processing)
- `process_slot` modified (`per_slot_processing`)
- `process_epoch` modified (`per_epoch_processing`)
  -  `process_builder_pending_payments` added
  -  `get_builder_payment_quorum_threshold` added

## How this works
`process_slot` will now unset the next slot's `BeaconState. execution_payload_availability`, which contains a ring buffer indexed per slot.  We clear the next slot's bit at every slot boundary as to start the slot off as a "no payload yet" state. 

`process_epoch` will now run `process_builder_pending_payments` at the end. The sole focus of this new function is to loop over the `state.builder_pending_payments` left over from the previous epoch that did not get converted to `state.builder_pending_withdrawals` during the fast past conversion because they were associated with CL blocks that did not release their corresponding execution envelopes.  So `process_builder_pending_payments` will check that if the accumulated weights for these `state.builder_pending_payments` from last epoch are higher than a quorum value. If so, they'll be converted to `builder_pending_withdrawal` with a `withdrawable_epoch`.