### PR TITLE
Gloas new p2p topics

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -130,6 +130,7 @@ pub struct BeaconProcessorQueueLengths {
     dcbroots_queue: usize,
     dcbrange_queue: usize,
     gossip_bls_to_execution_change_queue: usize,
+    gossip_execution_payload_queue: usize,
     lc_gossip_finality_update_queue: usize,
     lc_gossip_optimistic_update_queue: usize,
     lc_bootstrap_queue: usize,
@@ -196,6 +197,7 @@ impl BeaconProcessorQueueLengths {
             dcbroots_queue: 1024,
             dcbrange_queue: 1024,
             gossip_bls_to_execution_change_queue: 16384,
+            gossip_execution_payload_queue: 16384,
             lc_gossip_finality_update_queue: 1024,
             lc_gossip_optimistic_update_queue: 1024,
             lc_bootstrap_queue: 1024,
@@ -612,6 +614,7 @@ pub enum Work<E: EthSpec> {
     DataColumnsByRootsRequest(BlockingFn),
     DataColumnsByRangeRequest(BlockingFn),
     GossipBlsToExecutionChange(BlockingFn),
+    GossipExecutionPayload(BlockingFn),
     LightClientBootstrapRequest(BlockingFn),
     LightClientOptimisticUpdateRequest(BlockingFn),
     LightClientFinalityUpdateRequest(BlockingFn),
@@ -664,6 +667,7 @@ pub enum WorkType {
     DataColumnsByRootsRequest,
     DataColumnsByRangeRequest,
     GossipBlsToExecutionChange,
+    GossipExecutionPayload,
     LightClientBootstrapRequest,
     LightClientOptimisticUpdateRequest,
     LightClientFinalityUpdateRequest,
@@ -699,6 +703,7 @@ impl<E: EthSpec> Work<E> {
                 WorkType::GossipLightClientOptimisticUpdate
             }
             Work::GossipBlsToExecutionChange(_) => WorkType::GossipBlsToExecutionChange,
+            Work::GossipExecutionPayload(_) => WorkType::GossipExecutionPayload,
             Work::RpcBlock { .. } => WorkType::RpcBlock,
             Work::RpcBlobs { .. } => WorkType::RpcBlobs,
             Work::RpcCustodyColumn { .. } => WorkType::RpcCustodyColumn,
@@ -885,6 +890,8 @@ impl<E: EthSpec> BeaconProcessor<E> {
 
         let mut gossip_bls_to_execution_change_queue =
             FifoQueue::new(queue_lengths.gossip_bls_to_execution_change_queue);
+        let mut gossip_execution_payload_queue =
+            FifoQueue::new(queue_lengths.gossip_execution_payload_queue);
 
         // Using FIFO queues for light client updates to maintain sequence order.
         let mut lc_gossip_finality_update_queue =
@@ -1173,6 +1180,10 @@ impl<E: EthSpec> BeaconProcessor<E> {
                             // Convert any gossip attestations that need to be converted.
                             } else if let Some(item) = attestation_to_convert_queue.pop() {
                                 Some(item)
+                            // Check execution payload envelopes after attestations since they come later in the slot
+                            // TODO(EIP-7732): discuss with Mark where envelopes belong in terms of priority
+                            } else if let Some(item) = gossip_execution_payload_queue.pop() {
+                                Some(item)
                             // Check sync committee messages after attestations as their rewards are lesser
                             // and they don't influence fork choice.
                             } else if let Some(item) = sync_contribution_queue.pop() {
@@ -1384,6 +1395,9 @@ impl<E: EthSpec> BeaconProcessor<E> {
                             Work::GossipBlsToExecutionChange { .. } => {
                                 gossip_bls_to_execution_change_queue.push(work, work_id)
                             }
+                            Work::GossipExecutionPayload { .. } => {
+                                gossip_execution_payload_queue.push(work, work_id)
+                            }
                             Work::BlobsByRootsRequest { .. } => blbroots_queue.push(work, work_id),
                             Work::DataColumnsByRootsRequest { .. } => {
                                 dcbroots_queue.push(work, work_id)
@@ -1444,6 +1458,7 @@ impl<E: EthSpec> BeaconProcessor<E> {
                         WorkType::GossipBlsToExecutionChange => {
                             gossip_bls_to_execution_change_queue.len()
                         }
+                        WorkType::GossipExecutionPayload => gossip_execution_payload_queue.len(),
                         WorkType::LightClientBootstrapRequest => lc_bootstrap_queue.len(),
                         WorkType::LightClientOptimisticUpdateRequest => {
                             lc_rpc_optimistic_update_queue.len()
@@ -1624,6 +1639,7 @@ impl<E: EthSpec> BeaconProcessor<E> {
             | Work::GossipLightClientOptimisticUpdate(process_fn)
             | Work::Status(process_fn)
             | Work::GossipBlsToExecutionChange(process_fn)
+            | Work::GossipExecutionPayload(process_fn)
             | Work::LightClientBootstrapRequest(process_fn)
             | Work::LightClientOptimisticUpdateRequest(process_fn)
             | Work::LightClientFinalityUpdateRequest(process_fn)

--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -131,6 +131,7 @@ pub struct BeaconProcessorQueueLengths {
     dcbrange_queue: usize,
     gossip_bls_to_execution_change_queue: usize,
     gossip_execution_payload_queue: usize,
+    gossip_payload_attestation_message_queue: usize,
     lc_gossip_finality_update_queue: usize,
     lc_gossip_optimistic_update_queue: usize,
     lc_bootstrap_queue: usize,
@@ -197,7 +198,11 @@ impl BeaconProcessorQueueLengths {
             dcbroots_queue: 1024,
             dcbrange_queue: 1024,
             gossip_bls_to_execution_change_queue: 16384,
-            gossip_execution_payload_queue: 16384,
+            // TODO(EIP-7732): verify 1024 is preferable. I used same value as `gossip_block_queue` and `gossip_blob_queue`
+            gossip_execution_payload_queue: 1024,
+            // PTC size ~512 per slot, buffer 2-3 slots for reorgs and processing delays (512 * 3 = 1536)
+            // TODO(EIP-7732): verify if this is preferable queue length or otherwise
+            gossip_payload_attestation_message_queue: 1536,
             lc_gossip_finality_update_queue: 1024,
             lc_gossip_optimistic_update_queue: 1024,
             lc_bootstrap_queue: 1024,
@@ -615,6 +620,7 @@ pub enum Work<E: EthSpec> {
     DataColumnsByRangeRequest(BlockingFn),
     GossipBlsToExecutionChange(BlockingFn),
     GossipExecutionPayload(BlockingFn),
+    GossipPayloadAttestationMessage(BlockingFn),
     LightClientBootstrapRequest(BlockingFn),
     LightClientOptimisticUpdateRequest(BlockingFn),
     LightClientFinalityUpdateRequest(BlockingFn),
@@ -668,6 +674,7 @@ pub enum WorkType {
     DataColumnsByRangeRequest,
     GossipBlsToExecutionChange,
     GossipExecutionPayload,
+    GossipPayloadAttestationMessage,
     LightClientBootstrapRequest,
     LightClientOptimisticUpdateRequest,
     LightClientFinalityUpdateRequest,
@@ -704,6 +711,7 @@ impl<E: EthSpec> Work<E> {
             }
             Work::GossipBlsToExecutionChange(_) => WorkType::GossipBlsToExecutionChange,
             Work::GossipExecutionPayload(_) => WorkType::GossipExecutionPayload,
+            Work::GossipPayloadAttestationMessage(_) => WorkType::GossipPayloadAttestationMessage,
             Work::RpcBlock { .. } => WorkType::RpcBlock,
             Work::RpcBlobs { .. } => WorkType::RpcBlobs,
             Work::RpcCustodyColumn { .. } => WorkType::RpcCustodyColumn,
@@ -892,6 +900,8 @@ impl<E: EthSpec> BeaconProcessor<E> {
             FifoQueue::new(queue_lengths.gossip_bls_to_execution_change_queue);
         let mut gossip_execution_payload_queue =
             FifoQueue::new(queue_lengths.gossip_execution_payload_queue);
+        let mut gossip_payload_attestation_message_queue =
+            FifoQueue::new(queue_lengths.gossip_payload_attestation_message_queue);
 
         // Using FIFO queues for light client updates to maintain sequence order.
         let mut lc_gossip_finality_update_queue =
@@ -1037,232 +1047,238 @@ impl<E: EthSpec> BeaconProcessor<E> {
                     None if can_spawn => {
                         // Check for chain segments first, they're the most efficient way to get
                         // blocks into the system.
-                        let work_event: Option<Work<E>> =
-                            if let Some(item) = chain_segment_queue.pop() {
-                                Some(item)
-                            // Check sync blocks before gossip blocks, since we've already explicitly
-                            // requested these blocks.
-                            } else if let Some(item) = rpc_block_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = rpc_blob_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = rpc_custody_column_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = rpc_custody_column_queue.pop() {
-                                Some(item)
-                            // Check delayed blocks before gossip blocks, the gossip blocks might rely
-                            // on the delayed ones.
-                            } else if let Some(item) = delayed_block_queue.pop() {
-                                Some(item)
-                            // Check gossip blocks before gossip attestations, since a block might be
-                            // required to verify some attestations.
-                            } else if let Some(item) = gossip_block_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = gossip_blob_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = gossip_data_column_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = column_reconstruction_queue.pop() {
-                                Some(item)
-                            // Check the priority 0 API requests after blocks and blobs, but before attestations.
-                            } else if let Some(item) = api_request_p0_queue.pop() {
-                                Some(item)
-                            // Check the aggregates, *then* the unaggregates since we assume that
-                            // aggregates are more valuable to local validators and effectively give us
-                            // more information with less signature verification time.
-                            } else if aggregate_queue.len() > 0 {
-                                let batch_size = cmp::min(
-                                    aggregate_queue.len(),
-                                    self.config.max_gossip_aggregate_batch_size,
-                                );
+                        let work_event: Option<Work<E>> = if let Some(item) =
+                            chain_segment_queue.pop()
+                        {
+                            Some(item)
+                        // Check sync blocks before gossip blocks, since we've already explicitly
+                        // requested these blocks.
+                        } else if let Some(item) = rpc_block_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = rpc_blob_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = rpc_custody_column_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = rpc_custody_column_queue.pop() {
+                            Some(item)
+                        // Check delayed blocks before gossip blocks, the gossip blocks might rely
+                        // on the delayed ones.
+                        } else if let Some(item) = delayed_block_queue.pop() {
+                            Some(item)
+                        // Check gossip blocks before gossip attestations, since a block might be
+                        // required to verify some attestations.
+                        } else if let Some(item) = gossip_block_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = gossip_blob_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = gossip_data_column_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = column_reconstruction_queue.pop() {
+                            Some(item)
+                        // Check the priority 0 API requests after blocks and blobs, but before attestations.
+                        } else if let Some(item) = api_request_p0_queue.pop() {
+                            Some(item)
+                        // Check the aggregates, *then* the unaggregates since we assume that
+                        // aggregates are more valuable to local validators and effectively give us
+                        // more information with less signature verification time.
+                        } else if aggregate_queue.len() > 0 {
+                            let batch_size = cmp::min(
+                                aggregate_queue.len(),
+                                self.config.max_gossip_aggregate_batch_size,
+                            );
 
-                                if batch_size < 2 {
-                                    // One single aggregate is in the queue, process it individually.
-                                    aggregate_queue.pop()
-                                } else {
-                                    // Collect two or more aggregates into a batch, so they can take
-                                    // advantage of batch signature verification.
-                                    //
-                                    // Note: this will convert the `Work::GossipAggregate` item into a
-                                    // `Work::GossipAggregateBatch` item.
-                                    let mut aggregates = Vec::with_capacity(batch_size);
-                                    let mut process_batch_opt = None;
-                                    for _ in 0..batch_size {
-                                        if let Some(item) = aggregate_queue.pop() {
-                                            match item {
-                                                Work::GossipAggregate {
-                                                    aggregate,
-                                                    process_individual: _,
-                                                    process_batch,
-                                                } => {
-                                                    aggregates.push(*aggregate);
-                                                    if process_batch_opt.is_none() {
-                                                        process_batch_opt = Some(process_batch);
-                                                    }
-                                                }
-                                                _ => {
-                                                    error!("Invalid item in aggregate queue");
-                                                }
-                                            }
-                                        }
-                                    }
-
-                                    if let Some(process_batch) = process_batch_opt {
-                                        // Process all aggregates with a single worker.
-                                        Some(Work::GossipAggregateBatch {
-                                            aggregates,
-                                            process_batch,
-                                        })
-                                    } else {
-                                        // There is no good reason for this to
-                                        // happen, it is a serious logic error.
-                                        // Since we only form batches when multiple
-                                        // work items exist, we should always have a
-                                        // work closure at this point.
-                                        crit!("Missing aggregate work");
-                                        None
-                                    }
-                                }
-                            // Check the unaggregated attestation queue.
-                            //
-                            // Potentially use batching.
-                            } else if attestation_queue.len() > 0 {
-                                let batch_size = cmp::min(
-                                    attestation_queue.len(),
-                                    self.config.max_gossip_attestation_batch_size,
-                                );
-
-                                if batch_size < 2 {
-                                    // One single attestation is in the queue, process it individually.
-                                    attestation_queue.pop()
-                                } else {
-                                    // Collect two or more attestations into a batch, so they can take
-                                    // advantage of batch signature verification.
-                                    //
-                                    // Note: this will convert the `Work::GossipAttestation` item into a
-                                    // `Work::GossipAttestationBatch` item.
-                                    let mut attestations = Vec::with_capacity(batch_size);
-                                    let mut process_batch_opt = None;
-                                    for _ in 0..batch_size {
-                                        if let Some(item) = attestation_queue.pop() {
-                                            match item {
-                                                Work::GossipAttestation {
-                                                    attestation,
-                                                    process_individual: _,
-                                                    process_batch,
-                                                } => {
-                                                    attestations.push(*attestation);
-                                                    if process_batch_opt.is_none() {
-                                                        process_batch_opt = Some(process_batch);
-                                                    }
-                                                }
-                                                _ => error!("Invalid item in attestation queue"),
-                                            }
-                                        }
-                                    }
-
-                                    if let Some(process_batch) = process_batch_opt {
-                                        // Process all attestations with a single worker.
-                                        Some(Work::GossipAttestationBatch {
-                                            attestations,
-                                            process_batch,
-                                        })
-                                    } else {
-                                        // There is no good reason for this to
-                                        // happen, it is a serious logic error.
-                                        // Since we only form batches when multiple
-                                        // work items exist, we should always have a
-                                        // work closure at this point.
-                                        crit!("Missing attestations work");
-                                        None
-                                    }
-                                }
-                            // Convert any gossip attestations that need to be converted.
-                            } else if let Some(item) = attestation_to_convert_queue.pop() {
-                                Some(item)
-                            // Check execution payload envelopes after attestations since they come later in the slot
-                            // TODO(EIP-7732): discuss with Mark where envelopes belong in terms of priority
-                            } else if let Some(item) = gossip_execution_payload_queue.pop() {
-                                Some(item)
-                            // Check sync committee messages after attestations as their rewards are lesser
-                            // and they don't influence fork choice.
-                            } else if let Some(item) = sync_contribution_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = sync_message_queue.pop() {
-                                Some(item)
-                            // Aggregates and unaggregates queued for re-processing are older and we
-                            // care about fresher ones, so check those first.
-                            } else if let Some(item) = unknown_block_aggregate_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = unknown_block_attestation_queue.pop() {
-                                Some(item)
-                            // Check RPC methods next. Status messages are needed for sync so
-                            // prioritize them over syncing requests from other peers (BlocksByRange
-                            // and BlocksByRoot)
-                            } else if let Some(item) = status_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = bbrange_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = bbroots_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = blbrange_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = blbroots_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = dcbroots_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = dcbrange_queue.pop() {
-                                Some(item)
-                            // Check slashings after all other consensus messages so we prioritize
-                            // following head.
-                            //
-                            // Check attester slashings before proposer slashings since they have the
-                            // potential to slash multiple validators at once.
-                            } else if let Some(item) = gossip_attester_slashing_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = gossip_proposer_slashing_queue.pop() {
-                                Some(item)
-                            // Check exits and address changes late since our validators don't get
-                            // rewards from them.
-                            } else if let Some(item) = gossip_voluntary_exit_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = gossip_bls_to_execution_change_queue.pop() {
-                                Some(item)
-                            // Check the priority 1 API requests after we've
-                            // processed all the interesting things from the network
-                            // and things required for us to stay in good repute
-                            // with our P2P peers.
-                            } else if let Some(item) = api_request_p1_queue.pop() {
-                                Some(item)
-                            // Handle backfill sync chain segments.
-                            } else if let Some(item) = backfill_chain_segment.pop() {
-                                Some(item)
-                                // Handle light client requests.
-                            } else if let Some(item) = lc_gossip_finality_update_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = lc_gossip_optimistic_update_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = unknown_light_client_update_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = lc_bootstrap_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = lc_rpc_optimistic_update_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = lc_rpc_finality_update_queue.pop() {
-                                Some(item)
-                            } else if let Some(item) = lc_update_range_queue.pop() {
-                                Some(item)
-                                // This statement should always be the final else statement.
+                            if batch_size < 2 {
+                                // One single aggregate is in the queue, process it individually.
+                                aggregate_queue.pop()
                             } else {
-                                // Let the journal know that a worker is freed and there's nothing else
-                                // for it to do.
-                                if let Some(work_journal_tx) = &work_journal_tx {
-                                    // We don't care if this message was successfully sent, we only use the journal
-                                    // during testing.
-                                    let _ = work_journal_tx.try_send(NOTHING_TO_DO);
+                                // Collect two or more aggregates into a batch, so they can take
+                                // advantage of batch signature verification.
+                                //
+                                // Note: this will convert the `Work::GossipAggregate` item into a
+                                // `Work::GossipAggregateBatch` item.
+                                let mut aggregates = Vec::with_capacity(batch_size);
+                                let mut process_batch_opt = None;
+                                for _ in 0..batch_size {
+                                    if let Some(item) = aggregate_queue.pop() {
+                                        match item {
+                                            Work::GossipAggregate {
+                                                aggregate,
+                                                process_individual: _,
+                                                process_batch,
+                                            } => {
+                                                aggregates.push(*aggregate);
+                                                if process_batch_opt.is_none() {
+                                                    process_batch_opt = Some(process_batch);
+                                                }
+                                            }
+                                            _ => {
+                                                error!("Invalid item in aggregate queue");
+                                            }
+                                        }
+                                    }
                                 }
-                                None
-                            };
+
+                                if let Some(process_batch) = process_batch_opt {
+                                    // Process all aggregates with a single worker.
+                                    Some(Work::GossipAggregateBatch {
+                                        aggregates,
+                                        process_batch,
+                                    })
+                                } else {
+                                    // There is no good reason for this to
+                                    // happen, it is a serious logic error.
+                                    // Since we only form batches when multiple
+                                    // work items exist, we should always have a
+                                    // work closure at this point.
+                                    crit!("Missing aggregate work");
+                                    None
+                                }
+                            }
+                        // Check the unaggregated attestation queue.
+                        //
+                        // Potentially use batching.
+                        } else if attestation_queue.len() > 0 {
+                            let batch_size = cmp::min(
+                                attestation_queue.len(),
+                                self.config.max_gossip_attestation_batch_size,
+                            );
+
+                            if batch_size < 2 {
+                                // One single attestation is in the queue, process it individually.
+                                attestation_queue.pop()
+                            } else {
+                                // Collect two or more attestations into a batch, so they can take
+                                // advantage of batch signature verification.
+                                //
+                                // Note: this will convert the `Work::GossipAttestation` item into a
+                                // `Work::GossipAttestationBatch` item.
+                                let mut attestations = Vec::with_capacity(batch_size);
+                                let mut process_batch_opt = None;
+                                for _ in 0..batch_size {
+                                    if let Some(item) = attestation_queue.pop() {
+                                        match item {
+                                            Work::GossipAttestation {
+                                                attestation,
+                                                process_individual: _,
+                                                process_batch,
+                                            } => {
+                                                attestations.push(*attestation);
+                                                if process_batch_opt.is_none() {
+                                                    process_batch_opt = Some(process_batch);
+                                                }
+                                            }
+                                            _ => error!("Invalid item in attestation queue"),
+                                        }
+                                    }
+                                }
+
+                                if let Some(process_batch) = process_batch_opt {
+                                    // Process all attestations with a single worker.
+                                    Some(Work::GossipAttestationBatch {
+                                        attestations,
+                                        process_batch,
+                                    })
+                                } else {
+                                    // There is no good reason for this to
+                                    // happen, it is a serious logic error.
+                                    // Since we only form batches when multiple
+                                    // work items exist, we should always have a
+                                    // work closure at this point.
+                                    crit!("Missing attestations work");
+                                    None
+                                }
+                            }
+                        // Convert any gossip attestations that need to be converted.
+                        } else if let Some(item) = attestation_to_convert_queue.pop() {
+                            Some(item)
+                        }
+                        // Check execution payload envelopes after attestations since they come later in the slot
+                        // TODO(EIP-7732): discuss with Mark where envelopes belong in terms of priority
+                        else if let Some(item) = gossip_execution_payload_queue.pop() {
+                            Some(item)
+                        }
+                        // TODO(EIP-7732): discuss with Mark where envelopes belong in terms of priority
+                        else if let Some(item) = gossip_payload_attestation_message_queue.pop() {
+                            Some(item)
+                        // Check sync committee messages after attestations as their rewards are lesser
+                        // and they don't influence fork choice.
+                        } else if let Some(item) = sync_contribution_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = sync_message_queue.pop() {
+                            Some(item)
+                        // Aggregates and unaggregates queued for re-processing are older and we
+                        // care about fresher ones, so check those first.
+                        } else if let Some(item) = unknown_block_aggregate_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = unknown_block_attestation_queue.pop() {
+                            Some(item)
+                        // Check RPC methods next. Status messages are needed for sync so
+                        // prioritize them over syncing requests from other peers (BlocksByRange
+                        // and BlocksByRoot)
+                        } else if let Some(item) = status_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = bbrange_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = bbroots_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = blbrange_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = blbroots_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = dcbroots_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = dcbrange_queue.pop() {
+                            Some(item)
+                        // Check slashings after all other consensus messages so we prioritize
+                        // following head.
+                        //
+                        // Check attester slashings before proposer slashings since they have the
+                        // potential to slash multiple validators at once.
+                        } else if let Some(item) = gossip_attester_slashing_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = gossip_proposer_slashing_queue.pop() {
+                            Some(item)
+                        // Check exits and address changes late since our validators don't get
+                        // rewards from them.
+                        } else if let Some(item) = gossip_voluntary_exit_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = gossip_bls_to_execution_change_queue.pop() {
+                            Some(item)
+                        // Check the priority 1 API requests after we've
+                        // processed all the interesting things from the network
+                        // and things required for us to stay in good repute
+                        // with our P2P peers.
+                        } else if let Some(item) = api_request_p1_queue.pop() {
+                            Some(item)
+                        // Handle backfill sync chain segments.
+                        } else if let Some(item) = backfill_chain_segment.pop() {
+                            Some(item)
+                            // Handle light client requests.
+                        } else if let Some(item) = lc_gossip_finality_update_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = lc_gossip_optimistic_update_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = unknown_light_client_update_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = lc_bootstrap_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = lc_rpc_optimistic_update_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = lc_rpc_finality_update_queue.pop() {
+                            Some(item)
+                        } else if let Some(item) = lc_update_range_queue.pop() {
+                            Some(item)
+                            // This statement should always be the final else statement.
+                        } else {
+                            // Let the journal know that a worker is freed and there's nothing else
+                            // for it to do.
+                            if let Some(work_journal_tx) = &work_journal_tx {
+                                // We don't care if this message was successfully sent, we only use the journal
+                                // during testing.
+                                let _ = work_journal_tx.try_send(NOTHING_TO_DO);
+                            }
+                            None
+                        };
 
                         if let Some(work_event) = work_event {
                             let work_type = work_event.to_type();
@@ -1398,6 +1414,9 @@ impl<E: EthSpec> BeaconProcessor<E> {
                             Work::GossipExecutionPayload { .. } => {
                                 gossip_execution_payload_queue.push(work, work_id)
                             }
+                            Work::GossipPayloadAttestationMessage { .. } => {
+                                gossip_payload_attestation_message_queue.push(work, work_id)
+                            }
                             Work::BlobsByRootsRequest { .. } => blbroots_queue.push(work, work_id),
                             Work::DataColumnsByRootsRequest { .. } => {
                                 dcbroots_queue.push(work, work_id)
@@ -1459,6 +1478,9 @@ impl<E: EthSpec> BeaconProcessor<E> {
                             gossip_bls_to_execution_change_queue.len()
                         }
                         WorkType::GossipExecutionPayload => gossip_execution_payload_queue.len(),
+                        WorkType::GossipPayloadAttestationMessage => {
+                            gossip_payload_attestation_message_queue.len()
+                        }
                         WorkType::LightClientBootstrapRequest => lc_bootstrap_queue.len(),
                         WorkType::LightClientOptimisticUpdateRequest => {
                             lc_rpc_optimistic_update_queue.len()
@@ -1640,6 +1662,7 @@ impl<E: EthSpec> BeaconProcessor<E> {
             | Work::Status(process_fn)
             | Work::GossipBlsToExecutionChange(process_fn)
             | Work::GossipExecutionPayload(process_fn)
+            | Work::GossipPayloadAttestationMessage(process_fn)
             | Work::LightClientBootstrapRequest(process_fn)
             | Work::LightClientOptimisticUpdateRequest(process_fn)
             | Work::LightClientFinalityUpdateRequest(process_fn)

--- a/beacon_node/lighthouse_network/src/service/gossip_cache.rs
+++ b/beacon_node/lighthouse_network/src/service/gossip_cache.rs
@@ -42,6 +42,8 @@ pub struct GossipCache {
     bls_to_execution_change: Option<Duration>,
     /// Timeout for execution payload envelopes.
     execution_payload: Option<Duration>,
+    /// Timeout for payload attestation messages.
+    payload_attestation_message: Option<Duration>,
     /// Timeout for light client finality updates.
     light_client_finality_update: Option<Duration>,
     /// Timeout for light client optimistic updates.
@@ -75,6 +77,8 @@ pub struct GossipCacheBuilder {
     bls_to_execution_change: Option<Duration>,
     /// Timeout for execution payload envelopes.
     execution_payload: Option<Duration>,
+    /// Timeout for payload attestation messages.
+    payload_attestation_message: Option<Duration>,
     /// Timeout for light client finality updates.
     light_client_finality_update: Option<Duration>,
     /// Timeout for light client optimistic updates.
@@ -170,6 +174,7 @@ impl GossipCacheBuilder {
             sync_committee_message,
             bls_to_execution_change,
             execution_payload,
+            payload_attestation_message,
             light_client_finality_update,
             light_client_optimistic_update,
         } = self;
@@ -188,6 +193,7 @@ impl GossipCacheBuilder {
             sync_committee_message: sync_committee_message.or(default_timeout),
             bls_to_execution_change: bls_to_execution_change.or(default_timeout),
             execution_payload: execution_payload.or(default_timeout),
+            payload_attestation_message: payload_attestation_message.or(default_timeout),
             light_client_finality_update: light_client_finality_update.or(default_timeout),
             light_client_optimistic_update: light_client_optimistic_update.or(default_timeout),
         }
@@ -216,6 +222,7 @@ impl GossipCache {
             GossipKind::SyncCommitteeMessage(_) => self.sync_committee_message,
             GossipKind::BlsToExecutionChange => self.bls_to_execution_change,
             GossipKind::ExecutionPayload => self.execution_payload,
+            GossipKind::PayloadAttestationMessage => self.payload_attestation_message,
             GossipKind::LightClientFinalityUpdate => self.light_client_finality_update,
             GossipKind::LightClientOptimisticUpdate => self.light_client_optimistic_update,
         };

--- a/beacon_node/lighthouse_network/src/service/gossip_cache.rs
+++ b/beacon_node/lighthouse_network/src/service/gossip_cache.rs
@@ -40,6 +40,8 @@ pub struct GossipCache {
     sync_committee_message: Option<Duration>,
     /// Timeout for signed BLS to execution changes.
     bls_to_execution_change: Option<Duration>,
+    /// Timeout for execution payload envelopes.
+    execution_payload: Option<Duration>,
     /// Timeout for light client finality updates.
     light_client_finality_update: Option<Duration>,
     /// Timeout for light client optimistic updates.
@@ -71,6 +73,8 @@ pub struct GossipCacheBuilder {
     sync_committee_message: Option<Duration>,
     /// Timeout for signed BLS to execution changes.
     bls_to_execution_change: Option<Duration>,
+    /// Timeout for execution payload envelopes.
+    execution_payload: Option<Duration>,
     /// Timeout for light client finality updates.
     light_client_finality_update: Option<Duration>,
     /// Timeout for light client optimistic updates.
@@ -165,6 +169,7 @@ impl GossipCacheBuilder {
             signed_contribution_and_proof,
             sync_committee_message,
             bls_to_execution_change,
+            execution_payload,
             light_client_finality_update,
             light_client_optimistic_update,
         } = self;
@@ -182,6 +187,7 @@ impl GossipCacheBuilder {
             signed_contribution_and_proof: signed_contribution_and_proof.or(default_timeout),
             sync_committee_message: sync_committee_message.or(default_timeout),
             bls_to_execution_change: bls_to_execution_change.or(default_timeout),
+            execution_payload: execution_payload.or(default_timeout),
             light_client_finality_update: light_client_finality_update.or(default_timeout),
             light_client_optimistic_update: light_client_optimistic_update.or(default_timeout),
         }
@@ -209,6 +215,7 @@ impl GossipCache {
             GossipKind::SignedContributionAndProof => self.signed_contribution_and_proof,
             GossipKind::SyncCommitteeMessage(_) => self.sync_committee_message,
             GossipKind::BlsToExecutionChange => self.bls_to_execution_change,
+            GossipKind::ExecutionPayload => self.execution_payload,
             GossipKind::LightClientFinalityUpdate => self.light_client_finality_update,
             GossipKind::LightClientOptimisticUpdate => self.light_client_optimistic_update,
         };

--- a/beacon_node/lighthouse_network/src/types/pubsub.rs
+++ b/beacon_node/lighthouse_network/src/types/pubsub.rs
@@ -8,13 +8,15 @@ use std::io::{Error, ErrorKind};
 use std::sync::Arc;
 use types::{
     AttesterSlashing, AttesterSlashingBase, AttesterSlashingElectra, BlobSidecar,
-    DataColumnSidecar, DataColumnSubnetId, EthSpec, ForkContext, ForkVersionDecode,
+    DataColumnSidecar, DataColumnSubnetId, EthSpec, ForkContext, ForkName,
     LightClientFinalityUpdate, LightClientOptimisticUpdate, PayloadAttestationMessage,
     ProposerSlashing, SignedAggregateAndProof, SignedAggregateAndProofBase,
-    SignedAggregateAndProofElectra, SignedBeaconBlock, SignedBlsToExecutionChange,
-    SignedContributionAndProof, SignedExecutionPayloadEnvelope,
-    SignedExecutionPayloadEnvelopeGloas, SignedVoluntaryExit, SingleAttestation, SubnetId,
-    SyncCommitteeMessage, SyncSubnetId,
+    SignedAggregateAndProofElectra, SignedBeaconBlock, SignedBeaconBlockAltair,
+    SignedBeaconBlockBase, SignedBeaconBlockBellatrix, SignedBeaconBlockCapella,
+    SignedBeaconBlockDeneb, SignedBeaconBlockElectra, SignedBeaconBlockFulu,
+    SignedBeaconBlockGloas, SignedBlsToExecutionChange, SignedContributionAndProof,
+    SignedExecutionPayloadEnvelope, SignedExecutionPayloadEnvelopeGloas, SignedVoluntaryExit,
+    SingleAttestation, SubnetId, SyncCommitteeMessage, SyncSubnetId,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -216,11 +218,38 @@ impl<E: EthSpec> PubsubMessage<E> {
                         let beacon_block = match fork_context
                             .get_fork_from_context_bytes(gossip_topic.fork_digest)
                         {
-                            // TODO(EIP-7732): check with lighthouse team if there's any issue with simplifying to from_ssz_bytes_by_fork here. if so, perhaps we can add that as a comment
-                            Some(fork_name) => {
-                                SignedBeaconBlock::<E>::from_ssz_bytes_by_fork(data, *fork_name)
-                                    .map_err(|e| format!("{:?}", e))?
-                            }
+                            Some(ForkName::Base) => SignedBeaconBlock::<E>::Base(
+                                SignedBeaconBlockBase::from_ssz_bytes(data)
+                                    .map_err(|e| format!("{:?}", e))?,
+                            ),
+                            Some(ForkName::Altair) => SignedBeaconBlock::<E>::Altair(
+                                SignedBeaconBlockAltair::from_ssz_bytes(data)
+                                    .map_err(|e| format!("{:?}", e))?,
+                            ),
+                            Some(ForkName::Bellatrix) => SignedBeaconBlock::<E>::Bellatrix(
+                                SignedBeaconBlockBellatrix::from_ssz_bytes(data)
+                                    .map_err(|e| format!("{:?}", e))?,
+                            ),
+                            Some(ForkName::Capella) => SignedBeaconBlock::<E>::Capella(
+                                SignedBeaconBlockCapella::from_ssz_bytes(data)
+                                    .map_err(|e| format!("{:?}", e))?,
+                            ),
+                            Some(ForkName::Deneb) => SignedBeaconBlock::<E>::Deneb(
+                                SignedBeaconBlockDeneb::from_ssz_bytes(data)
+                                    .map_err(|e| format!("{:?}", e))?,
+                            ),
+                            Some(ForkName::Electra) => SignedBeaconBlock::<E>::Electra(
+                                SignedBeaconBlockElectra::from_ssz_bytes(data)
+                                    .map_err(|e| format!("{:?}", e))?,
+                            ),
+                            Some(ForkName::Fulu) => SignedBeaconBlock::<E>::Fulu(
+                                SignedBeaconBlockFulu::from_ssz_bytes(data)
+                                    .map_err(|e| format!("{:?}", e))?,
+                            ),
+                            Some(ForkName::Gloas) => SignedBeaconBlock::<E>::Gloas(
+                                SignedBeaconBlockGloas::from_ssz_bytes(data)
+                                    .map_err(|e| format!("{:?}", e))?,
+                            ),
                             None => {
                                 return Err(format!(
                                     "Unknown gossipsub fork digest: {:?}",

--- a/beacon_node/lighthouse_network/src/types/pubsub.rs
+++ b/beacon_node/lighthouse_network/src/types/pubsub.rs
@@ -9,11 +9,12 @@ use std::sync::Arc;
 use types::{
     AttesterSlashing, AttesterSlashingBase, AttesterSlashingElectra, BlobSidecar,
     DataColumnSidecar, DataColumnSubnetId, EthSpec, ForkContext, ForkVersionDecode,
-    LightClientFinalityUpdate, LightClientOptimisticUpdate, ProposerSlashing,
-    SignedAggregateAndProof, SignedAggregateAndProofBase, SignedAggregateAndProofElectra,
-    SignedBeaconBlock, SignedBlsToExecutionChange, SignedContributionAndProof,
-    SignedExecutionPayloadEnvelope, SignedExecutionPayloadEnvelopeGloas, SignedVoluntaryExit,
-    SingleAttestation, SubnetId, SyncCommitteeMessage, SyncSubnetId,
+    LightClientFinalityUpdate, LightClientOptimisticUpdate, PayloadAttestationMessage,
+    ProposerSlashing, SignedAggregateAndProof, SignedAggregateAndProofBase,
+    SignedAggregateAndProofElectra, SignedBeaconBlock, SignedBlsToExecutionChange,
+    SignedContributionAndProof, SignedExecutionPayloadEnvelope,
+    SignedExecutionPayloadEnvelopeGloas, SignedVoluntaryExit, SingleAttestation, SubnetId,
+    SyncCommitteeMessage, SyncSubnetId,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -42,6 +43,8 @@ pub enum PubsubMessage<E: EthSpec> {
     BlsToExecutionChange(Box<SignedBlsToExecutionChange>),
     /// Gossipsub message providing notification of a signed execution payload envelope.
     ExecutionPayload(Box<SignedExecutionPayloadEnvelope<E>>),
+    /// Gossipsub message providing notification of a payload attestation message.
+    PayloadAttestationMessage(Box<PayloadAttestationMessage>),
     /// Gossipsub message providing notification of a light client finality update.
     LightClientFinalityUpdate(Box<LightClientFinalityUpdate<E>>),
     /// Gossipsub message providing notification of a light client optimistic update.
@@ -146,6 +149,7 @@ impl<E: EthSpec> PubsubMessage<E> {
             PubsubMessage::SyncCommitteeMessage(data) => GossipKind::SyncCommitteeMessage(data.0),
             PubsubMessage::BlsToExecutionChange(_) => GossipKind::BlsToExecutionChange,
             PubsubMessage::ExecutionPayload(_) => GossipKind::ExecutionPayload,
+            PubsubMessage::PayloadAttestationMessage(_) => GossipKind::PayloadAttestationMessage,
             PubsubMessage::LightClientFinalityUpdate(_) => GossipKind::LightClientFinalityUpdate,
             PubsubMessage::LightClientOptimisticUpdate(_) => {
                 GossipKind::LightClientOptimisticUpdate
@@ -328,18 +332,16 @@ impl<E: EthSpec> PubsubMessage<E> {
                             .get_fork_from_context_bytes(gossip_topic.fork_digest)
                         {
                             Some(&fork_name) => {
-                                if fork_name.gloas_enabled() {
-                                    // TODO(EIP-7732): replace this with SignedExecutionPayloadEnvelope::from_ssz_bytes_for_fork once this branch is merged: https://github.com/shane-moore/lighthouse/tree/gloas-vc-publish-block
-                                    SignedExecutionPayloadEnvelope::Gloas(
-                                        SignedExecutionPayloadEnvelopeGloas::from_ssz_bytes(data)
-                                            .map_err(|e| format!("{:?}", e))?,
-                                    )
-                                } else {
+                                if !fork_name.gloas_enabled() {
                                     return Err(format!(
                                         "execution_payload topic not supported for fork {:?}",
                                         fork_name
                                     ));
                                 }
+                                SignedExecutionPayloadEnvelope::Gloas(
+                                    SignedExecutionPayloadEnvelopeGloas::from_ssz_bytes(data)
+                                        .map_err(|e| format!("{:?}", e))?,
+                                )
                             }
                             None => {
                                 return Err(format!(
@@ -350,6 +352,31 @@ impl<E: EthSpec> PubsubMessage<E> {
                         };
                         Ok(PubsubMessage::ExecutionPayload(Box::new(
                             signed_execution_payload_envelope,
+                        )))
+                    }
+                    GossipKind::PayloadAttestationMessage => {
+                        let payload_attestation_message = match fork_context
+                            .get_fork_from_context_bytes(gossip_topic.fork_digest)
+                        {
+                            Some(&fork_name) => {
+                                if !fork_name.gloas_enabled() {
+                                    return Err(format!(
+                                        "payload_attestation_message topic not supported for fork {:?}",
+                                        fork_name
+                                    ));
+                                }
+                                PayloadAttestationMessage::from_ssz_bytes(data)
+                                    .map_err(|e| format!("{:?}", e))?
+                            }
+                            None => {
+                                return Err(format!(
+                                    "payload_attestation_message topic invalid for given fork digest {:?}",
+                                    gossip_topic.fork_digest
+                                ));
+                            }
+                        };
+                        Ok(PubsubMessage::PayloadAttestationMessage(Box::new(
+                            payload_attestation_message,
                         )))
                     }
                     GossipKind::LightClientFinalityUpdate => {
@@ -415,6 +442,7 @@ impl<E: EthSpec> PubsubMessage<E> {
             PubsubMessage::SyncCommitteeMessage(data) => data.1.as_ssz_bytes(),
             PubsubMessage::BlsToExecutionChange(data) => data.as_ssz_bytes(),
             PubsubMessage::ExecutionPayload(data) => data.as_ssz_bytes(),
+            PubsubMessage::PayloadAttestationMessage(data) => data.as_ssz_bytes(),
             PubsubMessage::LightClientFinalityUpdate(data) => data.as_ssz_bytes(),
             PubsubMessage::LightClientOptimisticUpdate(data) => data.as_ssz_bytes(),
         }
@@ -476,6 +504,13 @@ impl<E: EthSpec> std::fmt::Display for PubsubMessage<E> {
                     "Signed Execution Payload Envelope: slot: {}, builder_index: {}",
                     data.message().slot(),
                     data.message().builder_index()
+                )
+            }
+            PubsubMessage::PayloadAttestationMessage(data) => {
+                write!(
+                    f,
+                    "Payload Attestation Message: validator_index: {}, slot: {}",
+                    data.validator_index, data.data.slot
                 )
             }
             PubsubMessage::LightClientFinalityUpdate(_data) => {

--- a/beacon_node/lighthouse_network/src/types/pubsub.rs
+++ b/beacon_node/lighthouse_network/src/types/pubsub.rs
@@ -8,14 +8,12 @@ use std::io::{Error, ErrorKind};
 use std::sync::Arc;
 use types::{
     AttesterSlashing, AttesterSlashingBase, AttesterSlashingElectra, BlobSidecar,
-    DataColumnSidecar, DataColumnSubnetId, EthSpec, ForkContext, ForkName,
+    DataColumnSidecar, DataColumnSubnetId, EthSpec, ForkContext, ForkVersionDecode,
     LightClientFinalityUpdate, LightClientOptimisticUpdate, ProposerSlashing,
     SignedAggregateAndProof, SignedAggregateAndProofBase, SignedAggregateAndProofElectra,
-    SignedBeaconBlock, SignedBeaconBlockAltair, SignedBeaconBlockBase, SignedBeaconBlockBellatrix,
-    SignedBeaconBlockCapella, SignedBeaconBlockDeneb, SignedBeaconBlockElectra,
-    SignedBeaconBlockFulu, SignedBeaconBlockGloas, SignedBlsToExecutionChange,
-    SignedContributionAndProof, SignedVoluntaryExit, SingleAttestation, SubnetId,
-    SyncCommitteeMessage, SyncSubnetId,
+    SignedBeaconBlock, SignedBlsToExecutionChange, SignedContributionAndProof,
+    SignedExecutionPayloadEnvelope, SignedExecutionPayloadEnvelopeGloas, SignedVoluntaryExit,
+    SingleAttestation, SubnetId, SyncCommitteeMessage, SyncSubnetId,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -42,6 +40,8 @@ pub enum PubsubMessage<E: EthSpec> {
     SyncCommitteeMessage(Box<(SyncSubnetId, SyncCommitteeMessage)>),
     /// Gossipsub message for BLS to execution change messages.
     BlsToExecutionChange(Box<SignedBlsToExecutionChange>),
+    /// Gossipsub message providing notification of a signed execution payload envelope.
+    ExecutionPayload(Box<SignedExecutionPayloadEnvelope<E>>),
     /// Gossipsub message providing notification of a light client finality update.
     LightClientFinalityUpdate(Box<LightClientFinalityUpdate<E>>),
     /// Gossipsub message providing notification of a light client optimistic update.
@@ -145,6 +145,7 @@ impl<E: EthSpec> PubsubMessage<E> {
             PubsubMessage::SignedContributionAndProof(_) => GossipKind::SignedContributionAndProof,
             PubsubMessage::SyncCommitteeMessage(data) => GossipKind::SyncCommitteeMessage(data.0),
             PubsubMessage::BlsToExecutionChange(_) => GossipKind::BlsToExecutionChange,
+            PubsubMessage::ExecutionPayload(_) => GossipKind::ExecutionPayload,
             PubsubMessage::LightClientFinalityUpdate(_) => GossipKind::LightClientFinalityUpdate,
             PubsubMessage::LightClientOptimisticUpdate(_) => {
                 GossipKind::LightClientOptimisticUpdate
@@ -211,38 +212,11 @@ impl<E: EthSpec> PubsubMessage<E> {
                         let beacon_block = match fork_context
                             .get_fork_from_context_bytes(gossip_topic.fork_digest)
                         {
-                            Some(ForkName::Base) => SignedBeaconBlock::<E>::Base(
-                                SignedBeaconBlockBase::from_ssz_bytes(data)
-                                    .map_err(|e| format!("{:?}", e))?,
-                            ),
-                            Some(ForkName::Altair) => SignedBeaconBlock::<E>::Altair(
-                                SignedBeaconBlockAltair::from_ssz_bytes(data)
-                                    .map_err(|e| format!("{:?}", e))?,
-                            ),
-                            Some(ForkName::Bellatrix) => SignedBeaconBlock::<E>::Bellatrix(
-                                SignedBeaconBlockBellatrix::from_ssz_bytes(data)
-                                    .map_err(|e| format!("{:?}", e))?,
-                            ),
-                            Some(ForkName::Capella) => SignedBeaconBlock::<E>::Capella(
-                                SignedBeaconBlockCapella::from_ssz_bytes(data)
-                                    .map_err(|e| format!("{:?}", e))?,
-                            ),
-                            Some(ForkName::Deneb) => SignedBeaconBlock::<E>::Deneb(
-                                SignedBeaconBlockDeneb::from_ssz_bytes(data)
-                                    .map_err(|e| format!("{:?}", e))?,
-                            ),
-                            Some(ForkName::Electra) => SignedBeaconBlock::<E>::Electra(
-                                SignedBeaconBlockElectra::from_ssz_bytes(data)
-                                    .map_err(|e| format!("{:?}", e))?,
-                            ),
-                            Some(ForkName::Fulu) => SignedBeaconBlock::<E>::Fulu(
-                                SignedBeaconBlockFulu::from_ssz_bytes(data)
-                                    .map_err(|e| format!("{:?}", e))?,
-                            ),
-                            Some(ForkName::Gloas) => SignedBeaconBlock::<E>::Gloas(
-                                SignedBeaconBlockGloas::from_ssz_bytes(data)
-                                    .map_err(|e| format!("{:?}", e))?,
-                            ),
+                            // TODO(EIP-7732): check with lighthouse team if there's any issue with simplifying to from_ssz_bytes_by_fork here. if so, perhaps we can add that as a comment
+                            Some(fork_name) => {
+                                SignedBeaconBlock::<E>::from_ssz_bytes_by_fork(data, *fork_name)
+                                    .map_err(|e| format!("{:?}", e))?
+                            }
                             None => {
                                 return Err(format!(
                                     "Unknown gossipsub fork digest: {:?}",
@@ -349,6 +323,35 @@ impl<E: EthSpec> PubsubMessage<E> {
                             bls_to_execution_change,
                         )))
                     }
+                    GossipKind::ExecutionPayload => {
+                        let signed_execution_payload_envelope = match fork_context
+                            .get_fork_from_context_bytes(gossip_topic.fork_digest)
+                        {
+                            Some(&fork_name) => {
+                                if fork_name.gloas_enabled() {
+                                    // TODO(EIP-7732): replace this with SignedExecutionPayloadEnvelope::from_ssz_bytes_for_fork once this branch is merged: https://github.com/shane-moore/lighthouse/tree/gloas-vc-publish-block
+                                    SignedExecutionPayloadEnvelope::Gloas(
+                                        SignedExecutionPayloadEnvelopeGloas::from_ssz_bytes(data)
+                                            .map_err(|e| format!("{:?}", e))?,
+                                    )
+                                } else {
+                                    return Err(format!(
+                                        "execution_payload topic not supported for fork {:?}",
+                                        fork_name
+                                    ));
+                                }
+                            }
+                            None => {
+                                return Err(format!(
+                                    "execution_payload topic invalid for given fork digest {:?}",
+                                    gossip_topic.fork_digest
+                                ));
+                            }
+                        };
+                        Ok(PubsubMessage::ExecutionPayload(Box::new(
+                            signed_execution_payload_envelope,
+                        )))
+                    }
                     GossipKind::LightClientFinalityUpdate => {
                         let light_client_finality_update = match fork_context
                             .get_fork_from_context_bytes(gossip_topic.fork_digest)
@@ -411,6 +414,7 @@ impl<E: EthSpec> PubsubMessage<E> {
             PubsubMessage::SignedContributionAndProof(data) => data.as_ssz_bytes(),
             PubsubMessage::SyncCommitteeMessage(data) => data.1.as_ssz_bytes(),
             PubsubMessage::BlsToExecutionChange(data) => data.as_ssz_bytes(),
+            PubsubMessage::ExecutionPayload(data) => data.as_ssz_bytes(),
             PubsubMessage::LightClientFinalityUpdate(data) => data.as_ssz_bytes(),
             PubsubMessage::LightClientOptimisticUpdate(data) => data.as_ssz_bytes(),
         }
@@ -464,6 +468,14 @@ impl<E: EthSpec> std::fmt::Display for PubsubMessage<E> {
                     f,
                     "Signed BLS to execution change: validator_index: {}, address: {:?}",
                     data.message.validator_index, data.message.to_execution_address
+                )
+            }
+            PubsubMessage::ExecutionPayload(data) => {
+                write!(
+                    f,
+                    "Signed Execution Payload Envelope: slot: {}, builder_index: {}",
+                    data.message().slot(),
+                    data.message().builder_index()
                 )
             }
             PubsubMessage::LightClientFinalityUpdate(_data) => {

--- a/beacon_node/lighthouse_network/src/types/topics.rs
+++ b/beacon_node/lighthouse_network/src/types/topics.rs
@@ -22,6 +22,7 @@ pub const ATTESTER_SLASHING_TOPIC: &str = "attester_slashing";
 pub const SIGNED_CONTRIBUTION_AND_PROOF_TOPIC: &str = "sync_committee_contribution_and_proof";
 pub const SYNC_COMMITTEE_PREFIX_TOPIC: &str = "sync_committee_";
 pub const BLS_TO_EXECUTION_CHANGE_TOPIC: &str = "bls_to_execution_change";
+pub const EXECUTION_PAYLOAD_TOPIC: &str = "execution_payload";
 pub const LIGHT_CLIENT_FINALITY_UPDATE: &str = "light_client_finality_update";
 pub const LIGHT_CLIENT_OPTIMISTIC_UPDATE: &str = "light_client_optimistic_update";
 
@@ -84,6 +85,10 @@ pub fn core_topics_to_subscribe<E: EthSpec>(
         }
     }
 
+    if fork_name.gloas_enabled() {
+        topics.push(GossipKind::ExecutionPayload);
+    }
+
     topics
 }
 
@@ -107,6 +112,7 @@ pub fn is_fork_non_core_topic(topic: &GossipTopic, _fork_name: ForkName) -> bool
         | GossipKind::AttesterSlashing
         | GossipKind::SignedContributionAndProof
         | GossipKind::BlsToExecutionChange
+        | GossipKind::ExecutionPayload
         | GossipKind::LightClientFinalityUpdate
         | GossipKind::LightClientOptimisticUpdate => false,
     }
@@ -164,6 +170,8 @@ pub enum GossipKind {
     SyncCommitteeMessage(SyncSubnetId),
     /// Topic for validator messages which change their withdrawal address.
     BlsToExecutionChange,
+    /// Topic for publishing execution payload envelopes.
+    ExecutionPayload,
     /// Topic for publishing finality updates for light clients.
     LightClientFinalityUpdate,
     /// Topic for publishing optimistic updates for light clients.
@@ -248,6 +256,7 @@ impl GossipTopic {
                 PROPOSER_SLASHING_TOPIC => GossipKind::ProposerSlashing,
                 ATTESTER_SLASHING_TOPIC => GossipKind::AttesterSlashing,
                 BLS_TO_EXECUTION_CHANGE_TOPIC => GossipKind::BlsToExecutionChange,
+                EXECUTION_PAYLOAD_TOPIC => GossipKind::ExecutionPayload,
                 LIGHT_CLIENT_FINALITY_UPDATE => GossipKind::LightClientFinalityUpdate,
                 LIGHT_CLIENT_OPTIMISTIC_UPDATE => GossipKind::LightClientOptimisticUpdate,
                 topic => match subnet_topic_index(topic) {
@@ -313,6 +322,7 @@ impl std::fmt::Display for GossipTopic {
                 format!("{}{}", DATA_COLUMN_SIDECAR_PREFIX, *column_subnet_id)
             }
             GossipKind::BlsToExecutionChange => BLS_TO_EXECUTION_CHANGE_TOPIC.into(),
+            GossipKind::ExecutionPayload => EXECUTION_PAYLOAD_TOPIC.into(),
             GossipKind::LightClientFinalityUpdate => LIGHT_CLIENT_FINALITY_UPDATE.into(),
             GossipKind::LightClientOptimisticUpdate => LIGHT_CLIENT_OPTIMISTIC_UPDATE.into(),
         };

--- a/beacon_node/lighthouse_network/src/types/topics.rs
+++ b/beacon_node/lighthouse_network/src/types/topics.rs
@@ -23,6 +23,7 @@ pub const SIGNED_CONTRIBUTION_AND_PROOF_TOPIC: &str = "sync_committee_contributi
 pub const SYNC_COMMITTEE_PREFIX_TOPIC: &str = "sync_committee_";
 pub const BLS_TO_EXECUTION_CHANGE_TOPIC: &str = "bls_to_execution_change";
 pub const EXECUTION_PAYLOAD_TOPIC: &str = "execution_payload";
+pub const PAYLOAD_ATTESTATION_MESSAGE_TOPIC: &str = "payload_attestation_message";
 pub const LIGHT_CLIENT_FINALITY_UPDATE: &str = "light_client_finality_update";
 pub const LIGHT_CLIENT_OPTIMISTIC_UPDATE: &str = "light_client_optimistic_update";
 
@@ -87,6 +88,7 @@ pub fn core_topics_to_subscribe<E: EthSpec>(
 
     if fork_name.gloas_enabled() {
         topics.push(GossipKind::ExecutionPayload);
+        topics.push(GossipKind::PayloadAttestationMessage);
     }
 
     topics
@@ -113,6 +115,7 @@ pub fn is_fork_non_core_topic(topic: &GossipTopic, _fork_name: ForkName) -> bool
         | GossipKind::SignedContributionAndProof
         | GossipKind::BlsToExecutionChange
         | GossipKind::ExecutionPayload
+        | GossipKind::PayloadAttestationMessage
         | GossipKind::LightClientFinalityUpdate
         | GossipKind::LightClientOptimisticUpdate => false,
     }
@@ -172,6 +175,8 @@ pub enum GossipKind {
     BlsToExecutionChange,
     /// Topic for publishing execution payload envelopes.
     ExecutionPayload,
+    /// Topic for publishing payload attestation messages.
+    PayloadAttestationMessage,
     /// Topic for publishing finality updates for light clients.
     LightClientFinalityUpdate,
     /// Topic for publishing optimistic updates for light clients.
@@ -257,6 +262,7 @@ impl GossipTopic {
                 ATTESTER_SLASHING_TOPIC => GossipKind::AttesterSlashing,
                 BLS_TO_EXECUTION_CHANGE_TOPIC => GossipKind::BlsToExecutionChange,
                 EXECUTION_PAYLOAD_TOPIC => GossipKind::ExecutionPayload,
+                PAYLOAD_ATTESTATION_MESSAGE_TOPIC => GossipKind::PayloadAttestationMessage,
                 LIGHT_CLIENT_FINALITY_UPDATE => GossipKind::LightClientFinalityUpdate,
                 LIGHT_CLIENT_OPTIMISTIC_UPDATE => GossipKind::LightClientOptimisticUpdate,
                 topic => match subnet_topic_index(topic) {
@@ -323,6 +329,7 @@ impl std::fmt::Display for GossipTopic {
             }
             GossipKind::BlsToExecutionChange => BLS_TO_EXECUTION_CHANGE_TOPIC.into(),
             GossipKind::ExecutionPayload => EXECUTION_PAYLOAD_TOPIC.into(),
+            GossipKind::PayloadAttestationMessage => PAYLOAD_ATTESTATION_MESSAGE_TOPIC.into(),
             GossipKind::LightClientFinalityUpdate => LIGHT_CLIENT_FINALITY_UPDATE.into(),
             GossipKind::LightClientOptimisticUpdate => LIGHT_CLIENT_OPTIMISTIC_UPDATE.into(),
         };

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -38,9 +38,10 @@ use tracing::{Instrument, Span, debug, error, info, instrument, trace, warn};
 use types::{
     Attestation, AttestationData, AttestationRef, AttesterSlashing, BlobSidecar, DataColumnSidecar,
     DataColumnSubnetId, EthSpec, Hash256, IndexedAttestation, LightClientFinalityUpdate,
-    LightClientOptimisticUpdate, ProposerSlashing, SignedAggregateAndProof, SignedBeaconBlock,
-    SignedBlsToExecutionChange, SignedContributionAndProof, SignedExecutionPayloadEnvelope,
-    SignedVoluntaryExit, SingleAttestation, Slot, SubnetId, SyncCommitteeMessage, SyncSubnetId,
+    LightClientOptimisticUpdate, PayloadAttestationMessage, ProposerSlashing,
+    SignedAggregateAndProof, SignedBeaconBlock, SignedBlsToExecutionChange,
+    SignedContributionAndProof, SignedExecutionPayloadEnvelope, SignedVoluntaryExit,
+    SingleAttestation, Slot, SubnetId, SyncCommitteeMessage, SyncSubnetId,
     beacon_block::BlockImportSource,
 };
 
@@ -3226,7 +3227,36 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         // TODO(EIP-7732): Implement proper execution payload envelope gossip processing.
         // This should integrate with the envelope_verification.rs module once it's implemented.
 
+        trace!(
+            %peer_id,
+            builder_index = execution_payload.message().builder_index(),
+            slot = %execution_payload.message().slot(),
+            beacon_block_root = %execution_payload.message().beacon_block_root(),
+            "Processing execution payload envelope"
+        );
+
         // For now, ignore all envelopes since verification is not implemented
+        self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
+    }
+
+    pub fn process_gossip_payload_attestation_message(
+        self: &Arc<Self>,
+        message_id: MessageId,
+        peer_id: PeerId,
+        payload_attestation_message: PayloadAttestationMessage,
+    ) {
+        // TODO(EIP-7732): Implement proper payload attestation message gossip processing.
+        // This should integrate with a payload_attestation_verification.rs module once it's implemented.
+
+        trace!(
+            %peer_id,
+            validator_index = payload_attestation_message.validator_index,
+            slot = %payload_attestation_message.data.slot,
+            beacon_block_root = %payload_attestation_message.data.beacon_block_root,
+            "Processing payload attestation message"
+        );
+
+        // For now, ignore all payload attestation messages since verification is not implemented
         self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
     }
 }

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -39,8 +39,9 @@ use types::{
     Attestation, AttestationData, AttestationRef, AttesterSlashing, BlobSidecar, DataColumnSidecar,
     DataColumnSubnetId, EthSpec, Hash256, IndexedAttestation, LightClientFinalityUpdate,
     LightClientOptimisticUpdate, ProposerSlashing, SignedAggregateAndProof, SignedBeaconBlock,
-    SignedBlsToExecutionChange, SignedContributionAndProof, SignedVoluntaryExit, SingleAttestation,
-    Slot, SubnetId, SyncCommitteeMessage, SyncSubnetId, beacon_block::BlockImportSource,
+    SignedBlsToExecutionChange, SignedContributionAndProof, SignedExecutionPayloadEnvelope,
+    SignedVoluntaryExit, SingleAttestation, Slot, SubnetId, SyncCommitteeMessage, SyncSubnetId,
+    beacon_block::BlockImportSource,
 };
 
 use beacon_processor::work_reprocessing_queue::QueuedColumnReconstruction;
@@ -3214,5 +3215,18 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             write_file(block_path, &block.as_ssz_bytes());
             write_file(error_path, error.to_string().as_bytes());
         }
+    }
+
+    pub fn process_gossip_execution_payload(
+        self: &Arc<Self>,
+        message_id: MessageId,
+        peer_id: PeerId,
+        execution_payload: SignedExecutionPayloadEnvelope<T::EthSpec>,
+    ) {
+        // TODO(EIP-7732): Implement proper execution payload envelope gossip processing.
+        // This should integrate with the envelope_verification.rs module once it's implemented.
+
+        // For now, ignore all envelopes since verification is not implemented
+        self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
     }
 }

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -440,6 +440,27 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         })
     }
 
+    pub fn send_gossip_payload_attestation_message(
+        self: &Arc<Self>,
+        message_id: MessageId,
+        peer_id: PeerId,
+        payload_attestation_message: Box<PayloadAttestationMessage>,
+    ) -> Result<(), Error<T::EthSpec>> {
+        let processor = self.clone();
+        let process_fn = move || {
+            processor.process_gossip_payload_attestation_message(
+                message_id,
+                peer_id,
+                *payload_attestation_message,
+            )
+        };
+
+        self.try_send(BeaconWorkEvent {
+            drop_during_sync: false,
+            work: Work::GossipPayloadAttestationMessage(Box::new(process_fn)),
+        })
+    }
+
     /// Create a new `Work` event for some block, where the result from computation (if any) is
     /// sent to the other side of `result_tx`.
     pub fn send_rpc_beacon_block(

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -423,6 +423,23 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         })
     }
 
+    pub fn send_gossip_execution_payload(
+        self: &Arc<Self>,
+        message_id: MessageId,
+        peer_id: PeerId,
+        execution_payload: Box<SignedExecutionPayloadEnvelope<T::EthSpec>>,
+    ) -> Result<(), Error<T::EthSpec>> {
+        let processor = self.clone();
+        let process_fn = move || {
+            processor.process_gossip_execution_payload(message_id, peer_id, *execution_payload)
+        };
+
+        self.try_send(BeaconWorkEvent {
+            drop_during_sync: false,
+            work: Work::GossipExecutionPayload(Box::new(process_fn)),
+        })
+    }
+
     /// Create a new `Work` event for some block, where the result from computation (if any) is
     /// sent to the other side of `result_tx`.
     pub fn send_rpc_beacon_block(

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -486,6 +486,16 @@ impl<T: BeaconChainTypes> Router<T> {
                             bls_to_execution_change,
                         ),
                 ),
+            PubsubMessage::ExecutionPayload(signed_execution_payload_envelope) => {
+                trace!(%peer_id, "Received a signed execution payload envelope");
+                self.handle_beacon_processor_send_result(
+                    self.network_beacon_processor.send_gossip_execution_payload(
+                        message_id,
+                        peer_id,
+                        signed_execution_payload_envelope,
+                    ),
+                )
+            }
         }
     }
 

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -496,6 +496,17 @@ impl<T: BeaconChainTypes> Router<T> {
                     ),
                 )
             }
+            PubsubMessage::PayloadAttestationMessage(payload_attestation_message) => {
+                trace!(%peer_id, "Received a payload attestation message");
+                self.handle_beacon_processor_send_result(
+                    self.network_beacon_processor
+                        .send_gossip_payload_attestation_message(
+                            message_id,
+                            peer_id,
+                            payload_attestation_message,
+                        ),
+                )
+            }
         }
     }
 

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -269,7 +269,9 @@ pub use crate::signed_beacon_block_header::SignedBeaconBlockHeader;
 pub use crate::signed_bls_to_execution_change::SignedBlsToExecutionChange;
 pub use crate::signed_contribution_and_proof::SignedContributionAndProof;
 pub use crate::signed_execution_payload_bid::SignedExecutionPayloadBid;
-pub use crate::signed_execution_payload_envelope::SignedExecutionPayloadEnvelope;
+pub use crate::signed_execution_payload_envelope::{
+    SignedExecutionPayloadEnvelope, SignedExecutionPayloadEnvelopeGloas,
+};
 pub use crate::signed_voluntary_exit::SignedVoluntaryExit;
 pub use crate::signing_data::{SignedRoot, SigningData};
 pub use crate::slot_epoch::{Epoch, Slot};


### PR DESCRIPTION
## New P2P Topics Added
- `execution_payload`
  - used to propagate execution payload messages as `SignedExecutionPayloadEnvelope` per the [spec](https://ethereum.github.io/consensus-specs/specs/gloas/p2p-interface/#execution_payload)
- `payload_attestation_message`
  -  used to propagate signed payload attestation message per the [spec](https://ethereum.github.io/consensus-specs/specs/gloas/p2p-interface/#payload_attestation_message)
  
## TODO
- there are a few todo's mentioned in the diffs that can likely be resolved via PR review.  More interesting is that the `execution_payload` gossiping flow will need to hook into the upcoming `envelope_verification.rs` for validation logic before forwarding on a received envelope.  Similarly, the `payload_attestation_message` will need to hook into a new `payload_attestation_verification.rs` module once that's implemented.