### PR TITLE
gloas container additions

### DIFF
--- a/beacon_node/store/src/partial_beacon_state.rs
+++ b/beacon_node/store/src/partial_beacon_state.rs
@@ -116,8 +116,11 @@ where
     )]
     pub latest_execution_payload_header: ExecutionPayloadHeaderFulu<E>,
 
-    #[superstruct(only(Gloas), partial_getter(rename = "latest_execution_bid_gloas"))]
-    pub latest_execution_bid: ExecutionBid,
+    #[superstruct(
+        only(Gloas),
+        partial_getter(rename = "latest_execution_payload_bid_gloas")
+    )]
+    pub latest_execution_payload_bid: ExecutionPayloadBid,
 
     // Capella
     #[superstruct(only(Capella, Deneb, Electra, Fulu, Gloas))]
@@ -480,7 +483,7 @@ impl<E: EthSpec> TryInto<BeaconState<E>> for PartialBeaconState<E> {
                     current_sync_committee,
                     next_sync_committee,
                     inactivity_scores,
-                    latest_execution_bid,
+                    latest_execution_payload_bid,
                     next_withdrawal_index,
                     next_withdrawal_validator_index,
                     deposit_requests_start_index,

--- a/consensus/state_processing/src/upgrade/gloas.rs
+++ b/consensus/state_processing/src/upgrade/gloas.rs
@@ -2,7 +2,7 @@ use bls::Hash256;
 use std::mem;
 use types::{
     BeaconState, BeaconStateError as Error, BeaconStateGloas, BitVector, BuilderPendingPayment,
-    ChainSpec, EthSpec, ExecutionBid, Fork, List, Vector,
+    ChainSpec, EthSpec, ExecutionPayloadBid, Fork, List, Vector,
 };
 
 /// Transform a `Fulu` state into a `Gloas` state.
@@ -68,7 +68,7 @@ pub fn upgrade_state_to_gloas<E: EthSpec>(
         current_sync_committee: pre.current_sync_committee.clone(),
         next_sync_committee: pre.next_sync_committee.clone(),
         // Execution Bid
-        latest_execution_bid: ExecutionBid::default(),
+        latest_execution_payload_bid: ExecutionPayloadBid::default(),
         // Capella
         next_withdrawal_index: pre.next_withdrawal_index,
         next_withdrawal_validator_index: pre.next_withdrawal_validator_index,

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -673,7 +673,7 @@ impl<E: EthSpec, Payload: AbstractExecPayload<E>> EmptyBlock for BeaconBlockGloa
                 voluntary_exits: VariableList::empty(),
                 sync_aggregate: SyncAggregate::empty(),
                 bls_to_execution_changes: VariableList::empty(),
-                signed_execution_bid: SignedExecutionBid::empty(),
+                signed_execution_payload_bid: SignedExecutionPayloadBid::empty(),
                 payload_attestations: VariableList::empty(),
                 _phantom: PhantomData,
             },

--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -135,7 +135,7 @@ pub struct BeaconBlockBody<E: EthSpec, Payload: AbstractExecPayload<E> = FullPay
     #[superstruct(only(Electra, Fulu))]
     pub execution_requests: ExecutionRequests<E>,
     #[superstruct(only(Gloas))]
-    pub signed_execution_bid: SignedExecutionBid,
+    pub signed_execution_payload_bid: SignedExecutionPayloadBid,
     #[superstruct(only(Gloas))]
     pub payload_attestations: VariableList<PayloadAttestation<E>, E::MaxPayloadAttestations>,
     #[superstruct(only(Base, Altair, Gloas))]
@@ -533,7 +533,7 @@ impl<E: EthSpec> From<BeaconBlockBodyGloas<E, BlindedPayload<E>>>
             voluntary_exits,
             sync_aggregate,
             bls_to_execution_changes,
-            signed_execution_bid,
+            signed_execution_payload_bid,
             payload_attestations,
             _phantom,
         } = body;
@@ -549,7 +549,7 @@ impl<E: EthSpec> From<BeaconBlockBodyGloas<E, BlindedPayload<E>>>
             voluntary_exits,
             sync_aggregate,
             bls_to_execution_changes,
-            signed_execution_bid,
+            signed_execution_payload_bid,
             payload_attestations,
             _phantom: PhantomData,
         }
@@ -867,7 +867,7 @@ impl<E: EthSpec> From<BeaconBlockBodyGloas<E, FullPayload<E>>>
             voluntary_exits,
             sync_aggregate,
             bls_to_execution_changes,
-            signed_execution_bid,
+            signed_execution_payload_bid,
             payload_attestations,
             _phantom,
         } = body;
@@ -884,7 +884,7 @@ impl<E: EthSpec> From<BeaconBlockBodyGloas<E, FullPayload<E>>>
                 voluntary_exits,
                 sync_aggregate,
                 bls_to_execution_changes,
-                signed_execution_bid,
+                signed_execution_payload_bid,
                 payload_attestations,
                 _phantom: PhantomData,
             },

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -518,7 +518,7 @@ where
     pub latest_execution_payload_header: ExecutionPayloadHeaderFulu<E>,
     #[superstruct(only(Gloas))]
     #[metastruct(exclude_from(tree_lists))]
-    pub latest_execution_bid: ExecutionBid,
+    pub latest_execution_payload_bid: ExecutionPayloadBid,
     #[superstruct(only(Capella, Deneb, Electra, Fulu, Gloas), partial_getter(copy))]
     #[serde(with = "serde_utils::quoted_u64")]
     #[metastruct(exclude_from(tree_lists))]
@@ -2144,7 +2144,7 @@ impl<E: EthSpec> BeaconState<E> {
             | BeaconState::Electra(_)
             | BeaconState::Fulu(_) => true,
             BeaconState::Gloas(state) => {
-                state.latest_execution_bid.block_hash == state.latest_block_hash
+                state.latest_execution_payload_bid.block_hash == state.latest_block_hash
             }
         }
     }

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -1709,12 +1709,6 @@ pub struct Config {
     #[serde(serialize_with = "serialize_fork_epoch")]
     #[serde(deserialize_with = "deserialize_fork_epoch")]
     pub gloas_fork_epoch: Option<MaybeQuoted<Epoch>>,
-    #[serde(default = "default_builder_payment_threshold_numerator")]
-    #[serde(with = "serde_utils::quoted_u64")]
-    pub builder_payment_threshold_numerator: u64,
-    #[serde(default = "default_builder_payment_threshold_denominator")]
-    #[serde(with = "serde_utils::quoted_u64")]
-    pub builder_payment_threshold_denominator: u64,
 
     #[serde(with = "serde_utils::quoted_u64")]
     seconds_per_slot: u64,
@@ -1876,14 +1870,6 @@ fn default_fulu_fork_version() -> [u8; 4] {
 fn default_gloas_fork_version() -> [u8; 4] {
     // This value shouldn't be used.
     [0xff, 0xff, 0xff, 0xff]
-}
-
-fn default_builder_payment_threshold_numerator() -> u64 {
-    6
-}
-
-fn default_builder_payment_threshold_denominator() -> u64 {
-    10
 }
 
 /// Placeholder value: 2^256-2^10 (115792089237316195423570985008687907853269984665640564039457584007913129638912).
@@ -2190,9 +2176,6 @@ impl Config {
                 .gloas_fork_epoch
                 .map(|epoch| MaybeQuoted { value: epoch }),
 
-            builder_payment_threshold_numerator: spec.builder_payment_threshold_numerator,
-            builder_payment_threshold_denominator: spec.builder_payment_threshold_denominator,
-
             seconds_per_slot: spec.seconds_per_slot,
             seconds_per_eth1_block: spec.seconds_per_eth1_block,
             min_validator_withdrawability_delay: spec.min_validator_withdrawability_delay,
@@ -2284,8 +2267,6 @@ impl Config {
             fulu_fork_version,
             gloas_fork_version,
             gloas_fork_epoch,
-            builder_payment_threshold_numerator,
-            builder_payment_threshold_denominator,
             seconds_per_slot,
             seconds_per_eth1_block,
             min_validator_withdrawability_delay,
@@ -2359,8 +2340,6 @@ impl Config {
             fulu_fork_version,
             gloas_fork_version,
             gloas_fork_epoch: gloas_fork_epoch.map(|q| q.value),
-            builder_payment_threshold_numerator,
-            builder_payment_threshold_denominator,
             seconds_per_slot,
             seconds_per_eth1_block,
             min_validator_withdrawability_delay,

--- a/consensus/types/src/execution_payload_bid.rs
+++ b/consensus/types/src/execution_payload_bid.rs
@@ -11,9 +11,8 @@ use tree_hash_derive::TreeHash;
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derivative(PartialEq, Hash)]
 #[context_deserialize(ForkName)]
-// This is what Potuz' spec calls an `ExecutionPayloadHeader` even though it's clearly a bid.
-// https://github.com/ethereum/consensus-specs/blob/bba2c7be148d6d921d2ca5e1cc528f5daaf456d9/specs/gloas/beacon-chain.md#executionpayloadheader
-pub struct ExecutionBid {
+// https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#executionpayloadbid
+pub struct ExecutionPayloadBid {
     pub parent_block_hash: ExecutionBlockHash,
     pub parent_block_root: Hash256,
     pub block_hash: ExecutionBlockHash,
@@ -29,11 +28,11 @@ pub struct ExecutionBid {
     pub blob_kzg_commitments_root: Hash256,
 }
 
-impl SignedRoot for ExecutionBid {}
+impl SignedRoot for ExecutionPayloadBid {}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    ssz_and_tree_hash_tests!(ExecutionBid);
+    ssz_and_tree_hash_tests!(ExecutionPayloadBid);
 }

--- a/consensus/types/src/execution_payload_envelope.rs
+++ b/consensus/types/src/execution_payload_envelope.rs
@@ -4,7 +4,6 @@ use beacon_block_body::KzgCommitments;
 use derivative::Derivative;
 use serde::de::{Deserializer, Error as _};
 use serde::{Deserialize, Serialize};
-use ssz::{Decode, DecodeError};
 use ssz_derive::{Decode, Encode};
 use superstruct::superstruct;
 use test_random_derive::TestRandom;
@@ -68,19 +67,6 @@ impl<'a, E: EthSpec> ExecutionPayloadEnvelopeRef<'a, E> {
         match self {
             Self::Gloas(envelope) => ExecutionPayloadRef::Gloas(&envelope.payload),
             Self::NextFork(envelope) => ExecutionPayloadRef::Gloas(&envelope.payload),
-        }
-    }
-}
-
-impl<E: EthSpec> ExecutionPayloadEnvelope<E> {
-    /// Custom SSZ decoder that takes a `ForkName` as context.
-    pub fn from_ssz_bytes_for_fork(bytes: &[u8], fork_name: ForkName) -> Result<Self, DecodeError> {
-        match fork_name {
-            ForkName::Gloas => ExecutionPayloadEnvelopeGloas::from_ssz_bytes(bytes)
-                .map(ExecutionPayloadEnvelope::Gloas),
-            _ => Err(DecodeError::BytesInvalid(format!(
-                "ExecutionPayloadEnvelope does not support fork {fork_name:?}"
-            ))),
         }
     }
 }

--- a/consensus/types/src/execution_payload_envelope.rs
+++ b/consensus/types/src/execution_payload_envelope.rs
@@ -4,6 +4,7 @@ use beacon_block_body::KzgCommitments;
 use derivative::Derivative;
 use serde::de::{Deserializer, Error as _};
 use serde::{Deserialize, Serialize};
+use ssz::{Decode, DecodeError};
 use ssz_derive::{Decode, Encode};
 use superstruct::superstruct;
 use test_random_derive::TestRandom;
@@ -59,6 +60,7 @@ pub struct ExecutionPayloadEnvelope<E: EthSpec> {
     pub state_root: Hash256,
 }
 
+impl<E: EthSpec> SignedRoot for ExecutionPayloadEnvelope<E> {}
 impl<'a, E: EthSpec> SignedRoot for ExecutionPayloadEnvelopeRef<'a, E> {}
 
 impl<'a, E: EthSpec> ExecutionPayloadEnvelopeRef<'a, E> {
@@ -66,6 +68,19 @@ impl<'a, E: EthSpec> ExecutionPayloadEnvelopeRef<'a, E> {
         match self {
             Self::Gloas(envelope) => ExecutionPayloadRef::Gloas(&envelope.payload),
             Self::NextFork(envelope) => ExecutionPayloadRef::Gloas(&envelope.payload),
+        }
+    }
+}
+
+impl<E: EthSpec> ExecutionPayloadEnvelope<E> {
+    /// Custom SSZ decoder that takes a `ForkName` as context.
+    pub fn from_ssz_bytes_for_fork(bytes: &[u8], fork_name: ForkName) -> Result<Self, DecodeError> {
+        match fork_name {
+            ForkName::Gloas => ExecutionPayloadEnvelopeGloas::from_ssz_bytes(bytes)
+                .map(ExecutionPayloadEnvelope::Gloas),
+            _ => Err(DecodeError::BytesInvalid(format!(
+                "ExecutionPayloadEnvelope does not support fork {fork_name:?}"
+            ))),
         }
     }
 }

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -42,9 +42,9 @@ pub mod dumb_macros;
 pub mod enr_fork_id;
 pub mod eth1_data;
 pub mod eth_spec;
-pub mod execution_bid;
 pub mod execution_block_hash;
 pub mod execution_payload;
+pub mod execution_payload_bid;
 pub mod execution_payload_envelope;
 pub mod execution_payload_header;
 pub mod fork;
@@ -77,7 +77,7 @@ pub mod signed_beacon_block;
 pub mod signed_beacon_block_header;
 pub mod signed_bls_to_execution_change;
 pub mod signed_contribution_and_proof;
-pub mod signed_execution_bid;
+pub mod signed_execution_payload_bid;
 pub mod signed_execution_payload_envelope;
 pub mod signed_voluntary_exit;
 pub mod signing_data;
@@ -178,7 +178,6 @@ pub use crate::enr_fork_id::EnrForkId;
 pub use crate::epoch_cache::{EpochCache, EpochCacheError, EpochCacheKey};
 pub use crate::eth_spec::EthSpecId;
 pub use crate::eth1_data::Eth1Data;
-pub use crate::execution_bid::ExecutionBid;
 pub use crate::execution_block_hash::ExecutionBlockHash;
 pub use crate::execution_block_header::{EncodableExecutionBlockHeader, ExecutionBlockHeader};
 pub use crate::execution_payload::{
@@ -186,6 +185,7 @@ pub use crate::execution_payload::{
     ExecutionPayloadElectra, ExecutionPayloadFulu, ExecutionPayloadGloas, ExecutionPayloadRef,
     Transaction, Transactions, Withdrawals,
 };
+pub use crate::execution_payload_bid::ExecutionPayloadBid;
 pub use crate::execution_payload_envelope::{
     ExecutionPayloadEnvelope, ExecutionPayloadEnvelopeGloas, ExecutionPayloadEnvelopeNextFork,
     ExecutionPayloadEnvelopeRef,
@@ -266,7 +266,7 @@ pub use crate::signed_beacon_block::{
 pub use crate::signed_beacon_block_header::SignedBeaconBlockHeader;
 pub use crate::signed_bls_to_execution_change::SignedBlsToExecutionChange;
 pub use crate::signed_contribution_and_proof::SignedContributionAndProof;
-pub use crate::signed_execution_bid::SignedExecutionBid;
+pub use crate::signed_execution_payload_bid::SignedExecutionPayloadBid;
 pub use crate::signed_execution_payload_envelope::SignedExecutionPayloadEnvelope;
 pub use crate::signed_voluntary_exit::SignedVoluntaryExit;
 pub use crate::signing_data::{SignedRoot, SigningData};

--- a/consensus/types/src/payload_attestation_message.rs
+++ b/consensus/types/src/payload_attestation_message.rs
@@ -12,7 +12,7 @@ pub struct PayloadAttestationMessage {
     #[serde(with = "serde_utils::quoted_u64")]
     pub validator_index: u64,
     pub data: PayloadAttestationData,
-    pub signature: AggregateSignature,
+    pub signature: Signature,
 }
 
 #[cfg(test)]

--- a/consensus/types/src/signed_execution_payload_bid.rs
+++ b/consensus/types/src/signed_execution_payload_bid.rs
@@ -12,16 +12,16 @@ use tree_hash_derive::TreeHash;
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derivative(PartialEq, Hash)]
 #[context_deserialize(ForkName)]
-// https://github.com/ethereum/consensus-specs/blob/bba2c7be148d6d921d2ca5e1cc528f5daaf456d9/specs/gloas/beacon-chain.md#signedexecutionpayloadheader
-pub struct SignedExecutionBid {
-    pub message: ExecutionBid,
+// https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#signedexecutionpayloadbid
+pub struct SignedExecutionPayloadBid {
+    pub message: ExecutionPayloadBid,
     pub signature: Signature,
 }
 
-impl SignedExecutionBid {
+impl SignedExecutionPayloadBid {
     pub fn empty() -> Self {
         Self {
-            message: ExecutionBid::default(),
+            message: ExecutionPayloadBid::default(),
             signature: Signature::empty(),
         }
     }
@@ -31,5 +31,5 @@ impl SignedExecutionBid {
 mod tests {
     use super::*;
 
-    ssz_and_tree_hash_tests!(SignedExecutionBid);
+    ssz_and_tree_hash_tests!(SignedExecutionPayloadBid);
 }

--- a/consensus/types/src/signed_execution_payload_envelope.rs
+++ b/consensus/types/src/signed_execution_payload_envelope.rs
@@ -48,6 +48,26 @@ pub struct SignedExecutionPayloadEnvelope<E: EthSpec> {
 }
 
 impl<E: EthSpec> SignedExecutionPayloadEnvelope<E> {
+    /// Create a new `SignedExecutionPayloadEnvelope` from an `ExecutionPayloadEnvelope` and `Signature`.
+    pub fn from_envelope(envelope: ExecutionPayloadEnvelope<E>, signature: Signature) -> Self {
+        match envelope {
+            ExecutionPayloadEnvelope::Gloas(message) => SignedExecutionPayloadEnvelope::Gloas(
+                signed_execution_payload_envelope::SignedExecutionPayloadEnvelopeGloas {
+                    message,
+                    signature,
+                },
+            ),
+            ExecutionPayloadEnvelope::NextFork(message) => {
+                SignedExecutionPayloadEnvelope::NextFork(
+                    signed_execution_payload_envelope::SignedExecutionPayloadEnvelopeNextFork {
+                        message,
+                        signature,
+                    },
+                )
+            }
+        }
+    }
+
     pub fn message(&self) -> ExecutionPayloadEnvelopeRef<'_, E> {
         match self {
             Self::Gloas(signed) => ExecutionPayloadEnvelopeRef::Gloas(&signed.message),


### PR DESCRIPTION
## Changes
- renamed execution payload header to execution payload bid ([#4525](https://github.com/ethereum/consensus-specs/pull/4525))
- removed `builder_payment_threshold_numerator` and `builder_payment_threshold_denominator` from `chain_spec` `Config` since are constants per the [spec](https://ethereum.github.io/consensus-specs/specs/gloas/beacon-chain/#misc)
- `PayloadAttestationMessage.signature` type  updated to `Signature` since is an unaggregated signature
- add some envelope decoding helpers, which are useful in later VC -> beacon node envelope requests PR's