### PR TITLE
Gloas vc ptc duty

### DIFF
--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -3354,6 +3354,8 @@ impl ApiTester {
         self
     }
 
+    // TODO(EIP-7732): Add test_get_validator_duties_ptc function to test PTC duties endpoint
+
     pub async fn test_get_validator_duties_early(self) -> Self {
         let current_epoch = self.chain.epoch().unwrap();
         let next_epoch = current_epoch + 1;

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -2933,6 +2933,8 @@ impl BeaconNodeHttpClient {
             .await
     }
 
+    // TODO(EIP-7732): Create corresponding beacon node response endpoint per spec
+    // https://github.com/ethereum/beacon-APIs/pull/552
     /// `POST validator/duties/ptc/{epoch}`
     pub async fn post_validator_duties_ptc(
         &self,

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -62,6 +62,8 @@ const HTTP_PROPOSER_DUTIES_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_SYNC_COMMITTEE_CONTRIBUTION_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_SYNC_DUTIES_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_SYNC_AGGREGATOR_TIMEOUT_QUOTIENT: u32 = 24; // For DVT involving middleware only
+// TODO(EIP-7732): Determine what this quotient should be
+const HTTP_PTC_DUTIES_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_GET_BEACON_BLOCK_SSZ_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT: u32 = 4;
 const HTTP_GET_DEPOSIT_SNAPSHOT_QUOTIENT: u32 = 4;
@@ -159,6 +161,7 @@ pub struct Timeouts {
     pub sync_committee_contribution: Duration,
     pub sync_duties: Duration,
     pub sync_aggregators: Duration,
+    pub ptc_duties: Duration,
     pub get_beacon_blocks_ssz: Duration,
     pub get_debug_beacon_states: Duration,
     pub get_deposit_snapshot: Duration,
@@ -179,6 +182,7 @@ impl Timeouts {
             sync_committee_contribution: timeout,
             sync_duties: timeout,
             sync_aggregators: timeout,
+            ptc_duties: timeout,
             get_beacon_blocks_ssz: timeout,
             get_debug_beacon_states: timeout,
             get_deposit_snapshot: timeout,
@@ -201,6 +205,7 @@ impl Timeouts {
                 / HTTP_SYNC_COMMITTEE_CONTRIBUTION_TIMEOUT_QUOTIENT,
             sync_duties: base_timeout / HTTP_SYNC_DUTIES_TIMEOUT_QUOTIENT,
             sync_aggregators: base_timeout / HTTP_SYNC_AGGREGATOR_TIMEOUT_QUOTIENT,
+            ptc_duties: base_timeout / HTTP_PTC_DUTIES_TIMEOUT_QUOTIENT,
             get_beacon_blocks_ssz: base_timeout / HTTP_GET_BEACON_BLOCK_SSZ_TIMEOUT_QUOTIENT,
             get_debug_beacon_states: base_timeout / HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT,
             get_deposit_snapshot: base_timeout / HTTP_GET_DEPOSIT_SNAPSHOT_QUOTIENT,
@@ -2926,6 +2931,29 @@ impl BeaconNodeHttpClient {
 
         self.post_with_timeout_and_response(path, &selections, self.timeouts.sync_aggregators)
             .await
+    }
+
+    /// `POST validator/duties/ptc/{epoch}`
+    pub async fn post_validator_duties_ptc(
+        &self,
+        epoch: Epoch,
+        indices: &[u64],
+    ) -> Result<DutiesResponse<Vec<PtcDuty>>, Error> {
+        let mut path = self.eth_path(V1)?;
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("validator")
+            .push("duties")
+            .push("ptc")
+            .push(&epoch.to_string());
+
+        self.post_with_timeout_and_response(
+            path,
+            &ValidatorIndexDataRef(indices),
+            self.timeouts.ptc_duties,
+        )
+        .await
     }
 }
 

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -780,6 +780,14 @@ pub struct ProposerData {
     pub slot: Slot,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PtcDuty {
+    pub pubkey: PublicKeyBytes,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub validator_index: u64,
+    pub slot: Slot,
+}
+
 #[derive(Clone, Deserialize)]
 pub struct ValidatorBlocksQuery {
     pub randao_reveal: SignatureBytes,

--- a/testing/simulator/src/checks.rs
+++ b/testing/simulator/src/checks.rs
@@ -219,6 +219,8 @@ pub async fn verify_full_sync_aggregates_up_to<E: EthSpec>(
     Ok(())
 }
 
+// TODO(EIP-7732): Add verify_ptc_duties_executed function to verify that PTC duties are being fetched and executed correctly when Gloas fork is enabled
+
 /// Verify that the first merged PoS block got finalized.
 pub async fn verify_transition_block_finalized<E: EthSpec>(
     network: LocalNetwork<E>,

--- a/validator_client/http_metrics/src/lib.rs
+++ b/validator_client/http_metrics/src/lib.rs
@@ -197,6 +197,16 @@ pub fn gather_prometheus_metrics<E: EthSpec>(
                 &[NEXT_EPOCH],
                 duties_service.attester_count(next_epoch) as i64,
             );
+            set_int_gauge(
+                &PTC_COUNT,
+                &[CURRENT_EPOCH],
+                duties_service.ptc_count(current_epoch) as i64,
+            );
+            set_int_gauge(
+                &PTC_COUNT,
+                &[NEXT_EPOCH],
+                duties_service.ptc_count(next_epoch) as i64,
+            );
         }
     }
 

--- a/validator_client/validator_metrics/src/lib.rs
+++ b/validator_client/validator_metrics/src/lib.rs
@@ -22,7 +22,12 @@ pub const UPDATE_ATTESTERS_CURRENT_EPOCH: &str = "update_attesters_current_epoch
 pub const UPDATE_ATTESTERS_NEXT_EPOCH: &str = "update_attesters_next_epoch";
 pub const UPDATE_ATTESTERS_FETCH: &str = "update_attesters_fetch";
 pub const UPDATE_ATTESTERS_STORE: &str = "update_attesters_store";
+pub const UPDATE_PTC_CURRENT_EPOCH: &str = "update_ptc_current_epoch";
+pub const UPDATE_PTC_NEXT_EPOCH: &str = "update_ptc_next_epoch";
+pub const UPDATE_PTC_FETCH: &str = "update_ptc_fetch";
+pub const UPDATE_PTC_STORE: &str = "update_ptc_store";
 pub const ATTESTER_DUTIES_HTTP_POST: &str = "attester_duties_http_post";
+pub const PTC_DUTIES_HTTP_POST: &str = "ptc_duties_http_post";
 pub const PROPOSER_DUTIES_HTTP_GET: &str = "proposer_duties_http_get";
 pub const VALIDATOR_DUTIES_SYNC_HTTP_POST: &str = "validator_duties_sync_http_post";
 pub const VALIDATOR_ID_HTTP_GET: &str = "validator_id_http_get";
@@ -159,6 +164,13 @@ pub static ATTESTER_COUNT: LazyLock<Result<IntGaugeVec>> = LazyLock::new(|| {
     try_create_int_gauge_vec(
         "vc_beacon_attester_count",
         "Number of attesters on this host",
+        &["task"],
+    )
+});
+pub static PTC_COUNT: LazyLock<Result<IntGaugeVec>> = LazyLock::new(|| {
+    try_create_int_gauge_vec(
+        "vc_beacon_ptc_count",
+        "Number of PTC (Payload Timeliness Committee) validators on this host",
         &["task"],
     )
 });

--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -12,7 +12,7 @@ use crate::sync::poll_sync_committee_duties;
 use beacon_node_fallback::{ApiTopic, BeaconNodeFallback};
 use eth2::types::{
     AttesterData, BeaconCommitteeSelection, BeaconCommitteeSubscription, DutiesResponse,
-    ProposerData, StateId, ValidatorId,
+    ProposerData, PtcDuty, StateId, ValidatorId,
 };
 use futures::{
     StreamExt,
@@ -45,6 +45,7 @@ const VALIDATOR_METRICS_MIN_COUNT: usize = 64;
 /// The initial request is used to determine if further requests are required, so that it
 /// reduces the amount of data that needs to be transferred.
 const INITIAL_DUTIES_QUERY_SIZE: usize = 1;
+const INITIAL_PTC_DUTIES_QUERY_SIZE: usize = 1;
 
 /// Offsets from the attestation duty slot at which a subscription should be sent.
 const ATTESTATION_SUBSCRIPTION_OFFSETS: [u64; 8] = [3, 4, 5, 6, 7, 8, 16, 32];
@@ -82,6 +83,7 @@ const _: () = assert!(ATTESTATION_SUBSCRIPTION_OFFSETS[0] > MIN_ATTESTATION_SUBS
 pub enum Error<T> {
     UnableToReadSlotClock,
     FailedToDownloadAttesters(#[allow(dead_code)] String),
+    FailedToDownloadPtc(#[allow(dead_code)] String),
     FailedToProduceSelectionProof(#[allow(dead_code)] ValidatorStoreError<T>),
     InvalidModulo(#[allow(dead_code)] ArithError),
     Arith(#[allow(dead_code)] ArithError),
@@ -275,6 +277,7 @@ type DependentRoot = Hash256;
 
 type AttesterMap = HashMap<PublicKeyBytes, HashMap<Epoch, (DependentRoot, DutyAndProof)>>;
 type ProposerMap = HashMap<Epoch, (DependentRoot, Vec<ProposerData>)>;
+type PtcMap = HashMap<Epoch, (DependentRoot, HashMap<PublicKeyBytes, PtcDuty>)>;
 
 pub struct DutiesServiceBuilder<S, T> {
     /// Provides the canonical list of locally-managed validators.
@@ -376,6 +379,7 @@ impl<S, T> DutiesServiceBuilder<S, T> {
             attesters: Default::default(),
             proposers: Default::default(),
             sync_duties: SyncDutiesMap::new(self.sync_selection_proof_config),
+            ptc_duties: Default::default(),
             validator_store: self
                 .validator_store
                 .ok_or("Cannot build DutiesService without validator_store")?,
@@ -406,6 +410,8 @@ pub struct DutiesService<S, T> {
     pub proposers: RwLock<ProposerMap>,
     /// Map from validator index to sync committee duties.
     pub sync_duties: SyncDutiesMap,
+    /// Maps an epoch to all *local* PTC duties for that epoch with their dependent root.
+    pub ptc_duties: RwLock<PtcMap>,
     /// Provides the canonical list of locally-managed validators.
     pub validator_store: Arc<S>,
     /// Maps unknown validator pubkeys to the next slot time when a poll should be conducted again.
@@ -462,6 +468,24 @@ impl<S: ValidatorStore, T: SlotClock + 'static> DutiesService<S, T> {
             .map(|(_, duty_and_proof)| duty_and_proof)
             .filter(|duty_and_proof| signing_pubkeys.contains(&duty_and_proof.duty.pubkey))
             .count()
+    }
+
+    /// Returns the total number of validators that have PTC duties in the given epoch.
+    pub fn ptc_count(&self, epoch: Epoch) -> usize {
+        // Only collect validators that are considered safe in terms of doppelganger protection.
+        let signing_pubkeys: HashSet<_> = self
+            .validator_store
+            .voting_pubkeys(DoppelgangerStatus::only_safe);
+        self.ptc_duties
+            .read()
+            .get(&epoch)
+            .map(|(_, duties)| {
+                duties
+                    .keys()
+                    .filter(|pubkey| signing_pubkeys.contains(pubkey))
+                    .count()
+            })
+            .unwrap_or(0)
     }
 
     /// Returns the total number of validators that are in a doppelganger detection period.
@@ -525,6 +549,25 @@ impl<S: ValidatorStore, T: SlotClock + 'static> DutiesService<S, T> {
     pub fn per_validator_metrics(&self) -> bool {
         self.enable_high_validator_count_metrics
             || self.total_validator_count() <= VALIDATOR_METRICS_MIN_COUNT
+    }
+
+    /// Get PTC duties for a specific slot.
+    ///
+    /// Returns duties for local validators who have PTC assignments at the given slot.
+    pub fn get_ptc_duties_for_slot(&self, slot: Slot) -> Vec<PtcDuty> {
+        let epoch = slot.epoch(S::E::slots_per_epoch());
+
+        self.ptc_duties
+            .read()
+            .get(&epoch)
+            .map(|(_, duties)| {
+                duties
+                    .values()
+                    .filter(|duty| duty.slot == slot)
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 }
 
@@ -654,6 +697,61 @@ pub fn start_update_service<S: ValidatorStore + 'static, T: SlotClock + 'static>
         },
         "duties_service_sync_committee",
     );
+
+    // Spawn the task which keeps track of local PTC duties.
+    // Only start PTC duties service if Gloas fork is scheduled.
+    if core_duties_service.spec.is_gloas_scheduled() {
+        let duties_service = core_duties_service.clone();
+        core_duties_service.executor.spawn(
+            async move {
+                loop {
+                    // Check if we've reached the Gloas fork epoch before polling
+                    let Some(current_slot) = duties_service.slot_clock.now() else {
+                        // Unable to read slot clock, sleep and try again
+                        sleep(duties_service.slot_clock.slot_duration()).await;
+                        continue;
+                    };
+
+                    let current_epoch = current_slot.epoch(S::E::slots_per_epoch());
+                    let Some(gloas_fork_epoch) = duties_service.spec.gloas_fork_epoch else {
+                        // Gloas fork epoch not configured, should not reach here
+                        break;
+                    };
+
+                    if current_epoch < gloas_fork_epoch {
+                        // Wait until the next slot and check again
+                        if let Some(duration) = duties_service.slot_clock.duration_to_next_slot() {
+                            sleep(duration).await;
+                        } else {
+                            sleep(duties_service.slot_clock.slot_duration()).await;
+                        }
+                        continue;
+                    }
+
+                    if let Err(e) = poll_beacon_ptc_attesters(&duties_service).await {
+                        error!(
+                            error = ?e,
+                           "Failed to poll PTC duties"
+                        );
+                    }
+
+                    // Wait until the next slot before polling again.
+                    // This doesn't mean that the beacon node will get polled every slot
+                    // as the PTC duties service will return early if it deems it already has
+                    // enough information.
+                    if let Some(duration) = duties_service.slot_clock.duration_to_next_slot() {
+                        sleep(duration).await;
+                    } else {
+                        // Just sleep for one slot if we are unable to read the system clock, this gives
+                        // us an opportunity for the clock to eventually come good.
+                        sleep(duties_service.slot_clock.slot_duration()).await;
+                        continue;
+                    }
+                }
+            },
+            "duties_service_ptc",
+        );
+    }
 }
 
 /// Iterate through all the voting pubkeys in the `ValidatorStore` and attempt to learn any unknown
@@ -1144,6 +1242,25 @@ fn get_uninitialized_validators<S: ValidatorStore, T: SlotClock + 'static>(
         .collect::<Vec<_>>()
 }
 
+/// Get a filtered list of local validators for which we don't already know their PTC duties for that epoch
+fn get_uninitialized_ptc_validators<S: ValidatorStore, T: SlotClock + 'static>(
+    duties_service: &Arc<DutiesService<S, T>>,
+    epoch: &Epoch,
+    local_pubkeys: &HashSet<PublicKeyBytes>,
+) -> Vec<u64> {
+    let ptc_duties = duties_service.ptc_duties.read();
+
+    local_pubkeys
+        .iter()
+        .filter(|pubkey| {
+            ptc_duties
+                .get(epoch)
+                .map_or(true, |(_, duties)| !duties.contains_key(pubkey))
+        })
+        .filter_map(|pubkey| duties_service.validator_store.validator_index(pubkey))
+        .collect::<Vec<_>>()
+}
+
 fn update_per_validator_duty_metrics<S: ValidatorStore, T: SlotClock + 'static>(
     duties_service: &Arc<DutiesService<S, T>>,
     epoch: Epoch,
@@ -1272,6 +1389,26 @@ fn process_duty_and_proof<S: ValidatorStore>(
             true
         }
     }
+}
+
+async fn post_validator_duties_ptc<S: ValidatorStore, T: SlotClock + 'static>(
+    duties_service: &Arc<DutiesService<S, T>>,
+    epoch: Epoch,
+    validator_indices: &[u64],
+) -> Result<DutiesResponse<Vec<PtcDuty>>, Error<S::Error>> {
+    duties_service
+        .beacon_nodes
+        .first_success(|beacon_node| async move {
+            let _timer = validator_metrics::start_timer_vec(
+                &validator_metrics::DUTIES_SERVICE_TIMES,
+                &[validator_metrics::PTC_DUTIES_HTTP_POST],
+            );
+            beacon_node
+                .post_validator_duties_ptc(epoch, validator_indices)
+                .await
+        })
+        .await
+        .map_err(|e| Error::FailedToDownloadPtc(e.to_string()))
 }
 
 /// Compute the attestation selection proofs for the `duties` and add them to the `attesters` map.
@@ -1559,6 +1696,222 @@ async fn poll_beacon_proposers<S: ValidatorStore, T: SlotClock + 'static>(
         .proposers
         .write()
         .retain(|&epoch, _| epoch + HISTORICAL_DUTIES_EPOCHS >= current_epoch);
+
+    Ok(())
+}
+
+/// Query the beacon node for ptc duties for any known validators.
+async fn poll_beacon_ptc_attesters<S: ValidatorStore + 'static, T: SlotClock + 'static>(
+    duties_service: &Arc<DutiesService<S, T>>,
+) -> Result<(), Error<S::Error>> {
+    let current_epoch_timer = validator_metrics::start_timer_vec(
+        &validator_metrics::DUTIES_SERVICE_TIMES,
+        &[validator_metrics::UPDATE_PTC_CURRENT_EPOCH],
+    );
+
+    let current_slot = duties_service
+        .slot_clock
+        .now()
+        .ok_or(Error::UnableToReadSlotClock)?;
+    let current_epoch = current_slot.epoch(S::E::slots_per_epoch());
+
+    // Collect *all* pubkeys, even those undergoing doppelganger protection.
+    let local_pubkeys: HashSet<_> = duties_service
+        .validator_store
+        .voting_pubkeys(DoppelgangerStatus::ignored);
+
+    let local_indices = {
+        let mut local_indices = Vec::with_capacity(local_pubkeys.len());
+
+        for &pubkey in &local_pubkeys {
+            if let Some(validator_index) = duties_service.validator_store.validator_index(&pubkey) {
+                local_indices.push(validator_index)
+            }
+        }
+        local_indices
+    };
+
+    // Poll for current epoch
+    if let Err(e) = poll_beacon_ptc_attesters_for_epoch(
+        duties_service,
+        current_epoch,
+        &local_indices,
+        &local_pubkeys,
+    )
+    .await
+    {
+        error!(
+            %current_epoch,
+            request_epoch = %current_epoch,
+            err = ?e,
+            "Failed to download PTC duties"
+        );
+    }
+    drop(current_epoch_timer);
+    let next_epoch_timer = validator_metrics::start_timer_vec(
+        &validator_metrics::DUTIES_SERVICE_TIMES,
+        &[validator_metrics::UPDATE_PTC_NEXT_EPOCH],
+    );
+
+    // Poll for next epoch
+    let next_epoch = current_epoch + 1;
+    if let Err(e) = poll_beacon_ptc_attesters_for_epoch(
+        duties_service,
+        next_epoch,
+        &local_indices,
+        &local_pubkeys,
+    )
+    .await
+    {
+        error!(
+            %current_epoch,
+            request_epoch = %next_epoch,
+            err = ?e,
+            "Failed to download PTC duties"
+        );
+    }
+    drop(next_epoch_timer);
+
+    // Prune old duties.
+    duties_service
+        .ptc_duties
+        .write()
+        .retain(|&epoch, _| epoch + HISTORICAL_DUTIES_EPOCHS >= current_epoch);
+
+    Ok(())
+}
+
+/// For the given `local_indices` and `local_pubkeys`, download the PTC duties for the given `epoch` and
+/// store them in `duties_service.ptc_duties` using bandwidth optimization.
+async fn poll_beacon_ptc_attesters_for_epoch<
+    S: ValidatorStore + 'static,
+    T: SlotClock + 'static,
+>(
+    duties_service: &Arc<DutiesService<S, T>>,
+    epoch: Epoch,
+    local_indices: &[u64],
+    local_pubkeys: &HashSet<PublicKeyBytes>,
+) -> Result<(), Error<S::Error>> {
+    // No need to bother the BN if we don't have any validators.
+    if local_indices.is_empty() {
+        debug!(
+            %epoch,
+            "No validators, not downloading PTC duties"
+        );
+        return Ok(());
+    }
+
+    let fetch_timer = validator_metrics::start_timer_vec(
+        &validator_metrics::DUTIES_SERVICE_TIMES,
+        &[validator_metrics::UPDATE_PTC_FETCH],
+    );
+
+    // Request duties for all uninitialized validators. If there isn't any, we will just request for
+    // `INITIAL_PTC_DUTIES_QUERY_SIZE` validators. We use the `dependent_root` in the response to
+    // determine whether validator duties need to be updated. This is to ensure that we don't
+    // request for extra data unless necessary in order to save on network bandwidth.
+    let uninitialized_validators =
+        get_uninitialized_ptc_validators(duties_service, &epoch, local_pubkeys);
+    let initial_indices_to_request = if !uninitialized_validators.is_empty() {
+        uninitialized_validators.as_slice()
+    } else {
+        &local_indices[0..min(INITIAL_PTC_DUTIES_QUERY_SIZE, local_indices.len())]
+    };
+
+    let response =
+        post_validator_duties_ptc(duties_service, epoch, initial_indices_to_request).await?;
+    let dependent_root = response.dependent_root;
+
+    // Check if we need to update duties for this epoch and collect validators to update.
+    // We update if we have no epoch data OR if the dependent_root changed.
+    let validators_to_update = {
+        // Avoid holding the read-lock for any longer than required.
+        let ptc_duties = duties_service.ptc_duties.read();
+        let needs_update = ptc_duties
+            .get(&epoch)
+            .map_or(true, |(prior_root, _duties)| {
+                // Update if dependent_root changed
+                *prior_root != dependent_root
+            });
+
+        if needs_update {
+            local_pubkeys.iter().collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        }
+    };
+
+    if validators_to_update.is_empty() {
+        // No validators have conflicting (epoch, dependent_root) values for this epoch.
+        return Ok(());
+    }
+
+    // Make a request for all indices that require updating which we have not already made a request for.
+    let indices_to_request = validators_to_update
+        .iter()
+        .filter_map(|pubkey| duties_service.validator_store.validator_index(pubkey))
+        .filter(|validator_index| !initial_indices_to_request.contains(validator_index))
+        .collect::<Vec<_>>();
+
+    // Filter the initial duties by their relevance so that we don't hit warnings about
+    // overwriting duties.
+    let new_initial_duties = response
+        .data
+        .into_iter()
+        .filter(|duty| validators_to_update.contains(&&duty.pubkey));
+
+    let mut new_duties = if !indices_to_request.is_empty() {
+        post_validator_duties_ptc(duties_service, epoch, indices_to_request.as_slice())
+            .await?
+            .data
+    } else {
+        vec![]
+    };
+    new_duties.extend(new_initial_duties);
+
+    drop(fetch_timer);
+
+    let _store_timer = validator_metrics::start_timer_vec(
+        &validator_metrics::DUTIES_SERVICE_TIMES,
+        &[validator_metrics::UPDATE_PTC_STORE],
+    );
+
+    debug!(
+        %dependent_root,
+        num_new_duties = new_duties.len(),
+        "Downloaded PTC duties"
+    );
+
+    // Update duties - we only reach here if dependent_root changed or epoch is missing
+    let mut ptc_duties = duties_service.ptc_duties.write();
+
+    let duties_by_pubkey: HashMap<PublicKeyBytes, PtcDuty> = new_duties
+        .into_iter()
+        .map(|duty| (duty.pubkey, duty))
+        .collect();
+
+    match ptc_duties.entry(epoch) {
+        hash_map::Entry::Occupied(mut entry) => {
+            // Dependent root must have changed, so we do complete replacement.
+            // We cannot support partial updates for the same dependent_root.
+            // The beacon node may return incomplete duty lists and we cannot distinguish between "no duties" and
+            // "duties not included in this response". We could query all local validators in each
+            // `post_validator_duties_ptc` call regardless of dependent_root changes, but the bandwidth
+            // cost is likely not justified since PTC assignments are sparse.
+            let (existing_root, _existing_duties) = entry.get();
+            debug!(
+                old_root = %existing_root,
+                new_root = %dependent_root,
+                "PTC dependent root changed, replacing all duties"
+            );
+
+            *entry.get_mut() = (dependent_root, duties_by_pubkey);
+        }
+        hash_map::Entry::Vacant(entry) => {
+            // No existing duties for this epoch
+            entry.insert((dependent_root, duties_by_pubkey));
+        }
+    }
 
     Ok(())
 }

--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -410,7 +410,7 @@ pub struct DutiesService<S, T> {
     pub proposers: RwLock<ProposerMap>,
     /// Map from validator index to sync committee duties.
     pub sync_duties: SyncDutiesMap,
-    /// Maps an epoch to all *local* PTC duties for that epoch with their dependent root.
+    /// Maps an epoch to PTC duties for locally-managed validators.
     pub ptc_duties: RwLock<PtcMap>,
     /// Provides the canonical list of locally-managed validators.
     pub validator_store: Arc<S>,
@@ -1242,25 +1242,6 @@ fn get_uninitialized_validators<S: ValidatorStore, T: SlotClock + 'static>(
         .collect::<Vec<_>>()
 }
 
-/// Get a filtered list of local validators for which we don't already know their PTC duties for that epoch
-fn get_uninitialized_ptc_validators<S: ValidatorStore, T: SlotClock + 'static>(
-    duties_service: &Arc<DutiesService<S, T>>,
-    epoch: &Epoch,
-    local_pubkeys: &HashSet<PublicKeyBytes>,
-) -> Vec<u64> {
-    let ptc_duties = duties_service.ptc_duties.read();
-
-    local_pubkeys
-        .iter()
-        .filter(|pubkey| {
-            ptc_duties
-                .get(epoch)
-                .map_or(true, |(_, duties)| !duties.contains_key(pubkey))
-        })
-        .filter_map(|pubkey| duties_service.validator_store.validator_index(pubkey))
-        .collect::<Vec<_>>()
-}
-
 fn update_per_validator_duty_metrics<S: ValidatorStore, T: SlotClock + 'static>(
     duties_service: &Arc<DutiesService<S, T>>,
     epoch: Epoch,
@@ -1806,17 +1787,12 @@ async fn poll_beacon_ptc_attesters_for_epoch<
         &[validator_metrics::UPDATE_PTC_FETCH],
     );
 
-    // Request duties for all uninitialized validators. If there isn't any, we will just request for
-    // `INITIAL_PTC_DUTIES_QUERY_SIZE` validators. We use the `dependent_root` in the response to
-    // determine whether validator duties need to be updated. This is to ensure that we don't
-    // request for extra data unless necessary in order to save on network bandwidth.
-    let uninitialized_validators =
-        get_uninitialized_ptc_validators(duties_service, &epoch, local_pubkeys);
-    let initial_indices_to_request = if !uninitialized_validators.is_empty() {
-        uninitialized_validators.as_slice()
-    } else {
-        &local_indices[0..min(INITIAL_PTC_DUTIES_QUERY_SIZE, local_indices.len())]
-    };
+    // Make a small initial request to check the dependent_root and determine if we need to fetch
+    // all duties. We use the `dependent_root` in the response to determine whether validator
+    // duties need to be updated. This is to ensure that we don't request for extra data unless
+    // necessary in order to save on network bandwidth.
+    let initial_indices_to_request =
+        &local_indices[0..min(INITIAL_PTC_DUTIES_QUERY_SIZE, local_indices.len())];
 
     let response =
         post_validator_duties_ptc(duties_service, epoch, initial_indices_to_request).await?;

--- a/validator_client/validator_services/src/notifier_service.rs
+++ b/validator_client/validator_services/src/notifier_service.rs
@@ -109,6 +109,7 @@ pub async fn notify<S: ValidatorStore, T: SlotClock + 'static>(
         let total_validators = duties_service.total_validator_count();
         let proposing_validators = duties_service.proposer_count(epoch);
         let attesting_validators = duties_service.attester_count(epoch);
+        let ptc_validators = duties_service.ptc_count(epoch);
         let doppelganger_detecting_validators = duties_service.doppelganger_detecting_count();
 
         if doppelganger_detecting_validators > 0 {
@@ -126,6 +127,7 @@ pub async fn notify<S: ValidatorStore, T: SlotClock + 'static>(
         } else if total_validators == attesting_validators {
             info!(
                 current_epoch_proposers = proposing_validators,
+                current_epoch_ptc = ptc_validators,
                 active_validators = attesting_validators,
                 total_validators = total_validators,
                 %epoch,
@@ -135,6 +137,7 @@ pub async fn notify<S: ValidatorStore, T: SlotClock + 'static>(
         } else if attesting_validators > 0 {
             info!(
                 current_epoch_proposers = proposing_validators,
+                current_epoch_ptc = ptc_validators,
                 active_validators = attesting_validators,
                 total_validators = total_validators,
                 %epoch,


### PR DESCRIPTION
## Changes
- added polling of ptc duties to the VC per [spec](https://ethereum.github.io/consensus-specs/specs/gloas/validator/#lookahead)

## How This Works
- The VC is currently checking whether one of its registered validators are in a voting committee, such as sync or attestation, or if they are the proposer for a slot.  With epbs, it's possible for a validator to also be in a ptc committee for at most one slot of the epoch.  More context on how validators are selected to be in a ptc was discussed on [discord](https://discord.com/channels/595666850260713488/874767108809031740/1430262787178758376).

## Implemented in the PR
`duties_service` will now spawn a background polling task for the current and next epoch to check whether any of the registered validators are in a ptc committee.  Since re-org is possible, we also poll every slot.  The beacon node querying is performed by new request endpoint `POST validator/duties/ptc/{epoch}` per [beacon api spec]( https://github.com/ethereum/beacon-APIs/pull/552).

To save on bandwidth similar to attestation committee polling, the ptc polling will make a tiny initial requests to learn the `dependent_root`, compare with the cached `dependent_root`, and only fetch full duties for the epoch if the root has changed (or if the root is unknown like for a new epoch).  Old duties are pruned based on `HISTORICAL_DUTIES_EPOCHS`. 


## Todo
- add tests noted in the diffs
- create beacon node (server side) response that will send the ptc duties to the VC.  Some of this work has already been done in other PR's such as the `get_ptc` helper, but the `warp` implementation still needs to be complete as to send the response to the VC