### PR TITLE
gloas vc block production

### DIFF
--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -7,6 +7,8 @@
 //! Eventually it would be ideal to publish this crate on crates.io, however we have some local
 //! dependencies preventing this presently.
 
+use ssz::{Decode, Encode};
+
 #[cfg(feature = "lighthouse")]
 pub mod lighthouse;
 #[cfg(feature = "lighthouse")]
@@ -15,8 +17,9 @@ pub mod mixin;
 pub mod types;
 
 use self::mixin::{RequestAccept, ResponseOptional};
-use self::types::{Error as ResponseError, *};
+use self::types::{Error as ResponseError, ExecutionPayloadEnvelopeMetadata, *};
 use ::types::beacon_response::ExecutionOptimisticFinalizedBeaconResponse;
+use ::types::{ExecutionPayloadEnvelope, ExecutionPayloadEnvelopeGloas, ForkName};
 use derivative::Derivative;
 use futures::Stream;
 use futures_util::StreamExt;
@@ -31,7 +34,6 @@ pub use reqwest::{StatusCode, Url};
 use reqwest_eventsource::{Event, EventSource};
 pub use sensitive_url::{SensitiveError, SensitiveUrl};
 use serde::{Serialize, de::DeserializeOwned};
-use ssz::Encode;
 use std::fmt;
 use std::future::Future;
 use std::path::PathBuf;
@@ -40,6 +42,7 @@ use std::time::Duration;
 pub const V1: EndpointVersion = EndpointVersion(1);
 pub const V2: EndpointVersion = EndpointVersion(2);
 pub const V3: EndpointVersion = EndpointVersion(3);
+pub const V4: EndpointVersion = EndpointVersion(4);
 
 pub const CONSENSUS_VERSION_HEADER: &str = "Eth-Consensus-Version";
 pub const EXECUTION_PAYLOAD_BLINDED_HEADER: &str = "Eth-Execution-Payload-Blinded";
@@ -66,6 +69,9 @@ const HTTP_GET_BEACON_BLOCK_SSZ_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT: u32 = 4;
 const HTTP_GET_DEPOSIT_SNAPSHOT_QUOTIENT: u32 = 4;
 const HTTP_GET_VALIDATOR_BLOCK_TIMEOUT_QUOTIENT: u32 = 4;
+// TODO(EIP-7732): determine what the envelope timeout should be
+const HTTP_GET_EXECUTION_PAYLOAD_ENVELOPE_TIMEOUT_QUOTIENT: u32 = 4;
+const HTTP_POST_EXECUTION_PAYLOAD_ENVELOPE_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_DEFAULT_TIMEOUT_QUOTIENT: u32 = 4;
 
 #[derive(Debug)]
@@ -163,6 +169,8 @@ pub struct Timeouts {
     pub get_debug_beacon_states: Duration,
     pub get_deposit_snapshot: Duration,
     pub get_validator_block: Duration,
+    pub get_execution_payload_envelope: Duration,
+    pub post_execution_payload_envelope: Duration,
     pub default: Duration,
 }
 
@@ -183,6 +191,8 @@ impl Timeouts {
             get_debug_beacon_states: timeout,
             get_deposit_snapshot: timeout,
             get_validator_block: timeout,
+            get_execution_payload_envelope: timeout,
+            post_execution_payload_envelope: timeout,
             default: timeout,
         }
     }
@@ -205,6 +215,10 @@ impl Timeouts {
             get_debug_beacon_states: base_timeout / HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT,
             get_deposit_snapshot: base_timeout / HTTP_GET_DEPOSIT_SNAPSHOT_QUOTIENT,
             get_validator_block: base_timeout / HTTP_GET_VALIDATOR_BLOCK_TIMEOUT_QUOTIENT,
+            get_execution_payload_envelope: base_timeout
+                / HTTP_GET_EXECUTION_PAYLOAD_ENVELOPE_TIMEOUT_QUOTIENT,
+            post_execution_payload_envelope: base_timeout
+                / HTTP_POST_EXECUTION_PAYLOAD_ENVELOPE_TIMEOUT_QUOTIENT,
             default: base_timeout / HTTP_DEFAULT_TIMEOUT_QUOTIENT,
         }
     }
@@ -1273,6 +1287,8 @@ impl BeaconNodeHttpClient {
     }
 
     /// `POST v2/beacon/blocks`
+    /// TODO(EIP-7732): Modify beacon node response endpoint per
+    ///  https://github.com/ethereum/beacon-APIs/pull/552.
     pub async fn post_beacon_blocks_v2_ssz<E: EthSpec>(
         &self,
         block_contents: &PublishBlockRequest<E>,
@@ -2261,16 +2277,17 @@ impl BeaconNodeHttpClient {
         Ok(path)
     }
 
-    /// returns `GET v3/validator/blocks/{slot}` URL path
-    pub async fn get_validator_blocks_v3_path(
+    /// returns `GET v3/validator/blocks/{slot}` or `GET v4/validator/blocks/{slot}` URL path
+    pub async fn get_validator_blocks_v3_and_v4_path(
         &self,
+        version: EndpointVersion,
         slot: Slot,
         randao_reveal: &SignatureBytes,
         graffiti: Option<&Graffiti>,
         skip_randao_verification: SkipRandaoVerification,
-        builder_booster_factor: Option<u64>,
+        builder_boost_factor: Option<u64>,
     ) -> Result<Url, Error> {
-        let mut path = self.eth_path(V3)?;
+        let mut path = self.eth_path(version)?;
 
         path.path_segments_mut()
             .map_err(|()| Error::InvalidUrl(self.server.clone()))?
@@ -2291,12 +2308,32 @@ impl BeaconNodeHttpClient {
                 .append_pair("skip_randao_verification", "");
         }
 
-        if let Some(builder_booster_factor) = builder_booster_factor {
+        if let Some(builder_boost_factor) = builder_boost_factor {
             path.query_pairs_mut()
-                .append_pair("builder_boost_factor", &builder_booster_factor.to_string());
+                .append_pair("builder_boost_factor", &builder_boost_factor.to_string());
         }
 
         Ok(path)
+    }
+
+    /// returns `GET v3/validator/blocks/{slot}` URL path (convenience method)
+    pub async fn get_validator_blocks_v3_path(
+        &self,
+        slot: Slot,
+        randao_reveal: &SignatureBytes,
+        graffiti: Option<&Graffiti>,
+        skip_randao_verification: SkipRandaoVerification,
+        builder_boost_factor: Option<u64>,
+    ) -> Result<Url, Error> {
+        self.get_validator_blocks_v3_and_v4_path(
+            V3,
+            slot,
+            randao_reveal,
+            graffiti,
+            skip_randao_verification,
+            builder_boost_factor,
+        )
+        .await
     }
 
     /// `GET v3/validator/blocks/{slot}`
@@ -2305,14 +2342,14 @@ impl BeaconNodeHttpClient {
         slot: Slot,
         randao_reveal: &SignatureBytes,
         graffiti: Option<&Graffiti>,
-        builder_booster_factor: Option<u64>,
+        builder_boost_factor: Option<u64>,
     ) -> Result<(JsonProduceBlockV3Response<E>, ProduceBlockV3Metadata), Error> {
         self.get_validator_blocks_v3_modular(
             slot,
             randao_reveal,
             graffiti,
             SkipRandaoVerification::No,
-            builder_booster_factor,
+            builder_boost_factor,
         )
         .await
     }
@@ -2324,7 +2361,7 @@ impl BeaconNodeHttpClient {
         randao_reveal: &SignatureBytes,
         graffiti: Option<&Graffiti>,
         skip_randao_verification: SkipRandaoVerification,
-        builder_booster_factor: Option<u64>,
+        builder_boost_factor: Option<u64>,
     ) -> Result<(JsonProduceBlockV3Response<E>, ProduceBlockV3Metadata), Error> {
         let path = self
             .get_validator_blocks_v3_path(
@@ -2332,7 +2369,7 @@ impl BeaconNodeHttpClient {
                 randao_reveal,
                 graffiti,
                 skip_randao_verification,
-                builder_booster_factor,
+                builder_boost_factor,
             )
             .await?;
 
@@ -2374,14 +2411,14 @@ impl BeaconNodeHttpClient {
         slot: Slot,
         randao_reveal: &SignatureBytes,
         graffiti: Option<&Graffiti>,
-        builder_booster_factor: Option<u64>,
+        builder_boost_factor: Option<u64>,
     ) -> Result<(ProduceBlockV3Response<E>, ProduceBlockV3Metadata), Error> {
         self.get_validator_blocks_v3_modular_ssz::<E>(
             slot,
             randao_reveal,
             graffiti,
             SkipRandaoVerification::No,
-            builder_booster_factor,
+            builder_boost_factor,
         )
         .await
     }
@@ -2393,7 +2430,7 @@ impl BeaconNodeHttpClient {
         randao_reveal: &SignatureBytes,
         graffiti: Option<&Graffiti>,
         skip_randao_verification: SkipRandaoVerification,
-        builder_booster_factor: Option<u64>,
+        builder_boost_factor: Option<u64>,
     ) -> Result<(ProduceBlockV3Response<E>, ProduceBlockV3Metadata), Error> {
         let path = self
             .get_validator_blocks_v3_path(
@@ -2401,7 +2438,7 @@ impl BeaconNodeHttpClient {
                 randao_reveal,
                 graffiti,
                 skip_randao_verification,
-                builder_booster_factor,
+                builder_boost_factor,
             )
             .await?;
 
@@ -2578,6 +2615,288 @@ impl BeaconNodeHttpClient {
 
         self.get_bytes_opt_accept_header(path, Accept::Ssz, self.timeouts.get_validator_block)
             .await
+    }
+
+    /// `GET v1/validator/execution_payload_envelope/{slot}/{builder_index}`
+    /// TODO(EIP-7732): Build out beacon node response endpoint per
+    /// https://github.com/ethereum/beacon-APIs/pull/552
+    /// Only client side request is implemented so far.
+    pub async fn get_execution_payload_envelope<E: EthSpec>(
+        &self,
+        slot: Slot,
+        builder_index: u64,
+    ) -> Result<ForkVersionedResponse<ExecutionPayloadEnvelope<E>>, Error> {
+        let path = self
+            .get_execution_payload_envelope_path(slot, builder_index)
+            .await?;
+
+        self.get_with_timeout(path, self.timeouts.get_execution_payload_envelope)
+            .await
+    }
+
+    /// `GET v1/validator/execution_payload_envelope/{slot}/{builder_index}` in SSZ format
+    /// TODO(EIP-7732): Build out beacon node response endpoint per
+    /// https://github.com/ethereum/beacon-APIs/pull/552
+    /// Only client side request is implemented so far.
+    pub async fn get_execution_payload_envelope_ssz<E: EthSpec>(
+        &self,
+        slot: Slot,
+        builder_index: u64,
+    ) -> Result<ExecutionPayloadEnvelope<E>, Error> {
+        let path = self
+            .get_execution_payload_envelope_path(slot, builder_index)
+            .await?;
+
+        let opt_response = self
+            .get_response_with_response_headers(
+                path,
+                Accept::Ssz,
+                self.timeouts.get_execution_payload_envelope,
+                |response, headers| async move {
+                    let metadata = ExecutionPayloadEnvelopeMetadata::try_from(&headers)
+                        .map_err(Error::InvalidHeaders)?;
+                    let response_bytes = response.bytes().await?;
+
+                    let envelope = if metadata.consensus_version.gloas_enabled() {
+                        ExecutionPayloadEnvelope::Gloas(
+                            ExecutionPayloadEnvelopeGloas::from_ssz_bytes(&response_bytes)
+                                .map_err(Error::InvalidSsz)?,
+                        )
+                    } else {
+                        return Err(Error::InvalidHeaders(format!(
+                            "ExecutionPayloadEnvelope not supported for fork: {:?}",
+                            metadata.consensus_version
+                        )));
+                    };
+
+                    Ok(envelope)
+                },
+            )
+            .await?;
+
+        // This route should never 404 unless unimplemented, so treat that as an error.
+        opt_response.ok_or(Error::StatusCode(StatusCode::NOT_FOUND))
+    }
+
+    /// returns `GET v1/validator/execution_payload_envelope/{slot}/{builder_index}` URL path
+    pub async fn get_execution_payload_envelope_path(
+        &self,
+        slot: Slot,
+        builder_index: u64,
+    ) -> Result<Url, Error> {
+        let mut path = self.eth_path(V1)?;
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("validator")
+            .push("execution_payload_envelope")
+            .push(&slot.to_string())
+            .push(&builder_index.to_string());
+
+        Ok(path)
+    }
+
+    /// `POST v1/beacon/execution_payload_envelope`
+    /// TODO(EIP-7732): Build out beacon node response endpoint per
+    /// https://github.com/ethereum/beacon-APIs/pull/552
+    /// Only client side request is implemented so far.
+    pub async fn post_execution_payload_envelope<E: EthSpec>(
+        &self,
+        envelope: &types::SignedExecutionPayloadEnvelope<E>,
+        fork_name: ForkName,
+    ) -> Result<(), Error> {
+        let mut path = self.eth_path(V1)?;
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("beacon")
+            .push("execution_payload_envelope");
+
+        self.post_generic_with_consensus_version(
+            path,
+            envelope,
+            Some(self.timeouts.post_execution_payload_envelope),
+            fork_name,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    /// `POST v1/beacon/execution_payload_envelope` in SSZ format
+    /// TODO(EIP-7732): Build out beacon node response endpoint per
+    /// https://github.com/ethereum/beacon-APIs/pull/552
+    /// Only client side request is implemented so far.
+    pub async fn post_execution_payload_envelope_ssz<E: EthSpec>(
+        &self,
+        envelope: &types::SignedExecutionPayloadEnvelope<E>,
+        fork_name: ForkName,
+    ) -> Result<(), Error> {
+        let mut path = self.eth_path(V1)?;
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("beacon")
+            .push("execution_payload_envelope");
+
+        self.post_generic_with_consensus_version_and_ssz_body(
+            path,
+            envelope.as_ssz_bytes(),
+            Some(self.timeouts.post_execution_payload_envelope),
+            fork_name,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    /// returns `GET v4/validator/blocks/{slot}` URL path
+    pub async fn get_validator_blocks_v4_path(
+        &self,
+        slot: Slot,
+        randao_reveal: &SignatureBytes,
+        graffiti: Option<&Graffiti>,
+        skip_randao_verification: SkipRandaoVerification,
+        builder_boost_factor: Option<u64>,
+    ) -> Result<Url, Error> {
+        self.get_validator_blocks_v3_and_v4_path(
+            V4,
+            slot,
+            randao_reveal,
+            graffiti,
+            skip_randao_verification,
+            builder_boost_factor,
+        )
+        .await
+    }
+
+    /// `GET v4/validator/blocks/{slot}` - Post-Gloas block production endpoint
+    /// This endpoint is specific to post-Gloas forks and only returns full blocks (no blinded concept)
+    /// TODO(EIP-7732): Build out beacon node response endpoint per
+    /// https://github.com/ethereum/beacon-APIs/pull/552
+    /// Only client side request is implemented so far.
+    pub async fn get_validator_blocks_v4<E: EthSpec>(
+        &self,
+        slot: Slot,
+        randao_reveal: &SignatureBytes,
+        graffiti: Option<&Graffiti>,
+        builder_boost_factor: Option<u64>,
+    ) -> Result<(JsonProduceBlockV4Response<E>, ProduceBlockV4Metadata), Error> {
+        self.get_validator_blocks_v4_modular(
+            slot,
+            randao_reveal,
+            graffiti,
+            SkipRandaoVerification::No,
+            builder_boost_factor,
+        )
+        .await
+    }
+
+    /// `GET v4/validator/blocks/{slot}` - Post-Gloas block production endpoint (modular version)
+    pub async fn get_validator_blocks_v4_modular<E: EthSpec>(
+        &self,
+        slot: Slot,
+        randao_reveal: &SignatureBytes,
+        graffiti: Option<&Graffiti>,
+        skip_randao_verification: SkipRandaoVerification,
+        builder_boost_factor: Option<u64>,
+    ) -> Result<(JsonProduceBlockV4Response<E>, ProduceBlockV4Metadata), Error> {
+        let path = self
+            .get_validator_blocks_v4_path(
+                slot,
+                randao_reveal,
+                graffiti,
+                skip_randao_verification,
+                builder_boost_factor,
+            )
+            .await?;
+
+        let opt_result = self
+            .get_response_with_response_headers(
+                path,
+                Accept::Json,
+                self.timeouts.get_validator_block,
+                |response, headers| async move {
+                    let header_metadata = ProduceBlockV4Metadata::try_from(&headers)
+                        .map_err(Error::InvalidHeaders)?;
+
+                    let block_response = response
+                        .json::<ForkVersionedResponse<ProduceBlockV4Response<E>, ProduceBlockV4Metadata>>()
+                        .await?;
+
+                    Ok((block_response, header_metadata))
+                },
+            )
+            .await?;
+
+        // This route should never 404 unless unimplemented, so treat that as an error.
+        opt_result.ok_or(Error::StatusCode(StatusCode::NOT_FOUND))
+    }
+
+    /// `GET v4/validator/blocks/{slot}` in SSZ format
+    /// TODO(EIP-7732): Build out beacon node response endpoint per
+    /// https://github.com/ethereum/beacon-APIs/pull/552
+    /// Only client side request is implemented so far.
+    pub async fn get_validator_blocks_v4_ssz<E: EthSpec>(
+        &self,
+        slot: Slot,
+        randao_reveal: &SignatureBytes,
+        graffiti: Option<&Graffiti>,
+        builder_boost_factor: Option<u64>,
+    ) -> Result<(ProduceBlockV4Response<E>, ProduceBlockV4Metadata), Error> {
+        self.get_validator_blocks_v4_modular_ssz::<E>(
+            slot,
+            randao_reveal,
+            graffiti,
+            SkipRandaoVerification::No,
+            builder_boost_factor,
+        )
+        .await
+    }
+
+    /// `GET v4/validator/blocks/{slot}` in SSZ format
+    pub async fn get_validator_blocks_v4_modular_ssz<E: EthSpec>(
+        &self,
+        slot: Slot,
+        randao_reveal: &SignatureBytes,
+        graffiti: Option<&Graffiti>,
+        skip_randao_verification: SkipRandaoVerification,
+        builder_boost_factor: Option<u64>,
+    ) -> Result<(ProduceBlockV4Response<E>, ProduceBlockV4Metadata), Error> {
+        let path = self
+            .get_validator_blocks_v4_path(
+                slot,
+                randao_reveal,
+                graffiti,
+                skip_randao_verification,
+                builder_boost_factor,
+            )
+            .await?;
+
+        let opt_response = self
+            .get_response_with_response_headers(
+                path,
+                Accept::Ssz,
+                self.timeouts.get_validator_block,
+                |response, headers| async move {
+                    let metadata = ProduceBlockV4Metadata::try_from(&headers)
+                        .map_err(Error::InvalidHeaders)?;
+                    let response_bytes = response.bytes().await?;
+
+                    // Parse SSZ bytes directly as BeaconBlock (ProduceBlockV4Response is just a type alias)
+                    let response = BeaconBlock::from_ssz_bytes_for_fork(
+                        &response_bytes,
+                        metadata.consensus_version,
+                    )
+                    .map_err(Error::InvalidSsz)?;
+
+                    Ok((response, metadata))
+                },
+            )
+            .await?;
+
+        // This route should never 404 unless unimplemented, so treat that as an error.
+        opt_response.ok_or(Error::StatusCode(StatusCode::NOT_FOUND))
     }
 
     /// `GET validator/attestation_data?slot,committee_index`

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1752,6 +1752,41 @@ pub struct ProduceBlockV3Metadata {
     pub consensus_block_value: Uint256,
 }
 
+/// Metadata about a `ExecutionPayloadEnvelope` response which is returned in the headers.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ExecutionPayloadEnvelopeMetadata {
+    // The consensus version is serialized & deserialized by `ForkVersionedResponse`.
+    #[serde(
+        skip_serializing,
+        skip_deserializing,
+        default = "dummy_consensus_version"
+    )]
+    pub consensus_version: ForkName,
+}
+
+/// Response from the `/eth/v4/validator/blocks/{slot}` endpoint.
+///
+/// V4 is specific to post-Gloas forks and always returns a BeaconBlock directly.
+/// No blinded/unblinded concept exists in Gloas.
+pub type ProduceBlockV4Response<E> = BeaconBlock<E>;
+
+pub type JsonProduceBlockV4Response<E> =
+    ForkVersionedResponse<ProduceBlockV4Response<E>, ProduceBlockV4Metadata>;
+
+/// Metadata about a `ProduceBlockV4Response` which is returned in the body & headers.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ProduceBlockV4Metadata {
+    // The consensus version is serialized & deserialized by `ForkVersionedResponse`.
+    #[serde(
+        skip_serializing,
+        skip_deserializing,
+        default = "dummy_consensus_version"
+    )]
+    pub consensus_version: ForkName,
+    #[serde(with = "serde_utils::u256_dec")]
+    pub consensus_block_value: Uint256,
+}
+
 impl<E: EthSpec> FullBlockContents<E> {
     pub fn new(block: BeaconBlock<E>, blob_data: Option<(KzgProofs<E>, BlobsList<E>)>) -> Self {
         match blob_data {
@@ -1903,6 +1938,40 @@ impl TryFrom<&HeaderMap> for ProduceBlockV3Metadata {
             consensus_version,
             execution_payload_blinded,
             execution_payload_value,
+            consensus_block_value,
+        })
+    }
+}
+
+impl TryFrom<&HeaderMap> for ExecutionPayloadEnvelopeMetadata {
+    type Error = String;
+
+    fn try_from(headers: &HeaderMap) -> Result<Self, Self::Error> {
+        let consensus_version = parse_required_header(headers, CONSENSUS_VERSION_HEADER, |s| {
+            s.parse::<ForkName>()
+                .map_err(|e| format!("invalid {CONSENSUS_VERSION_HEADER}: {e:?}"))
+        })?;
+
+        Ok(ExecutionPayloadEnvelopeMetadata { consensus_version })
+    }
+}
+
+impl TryFrom<&HeaderMap> for ProduceBlockV4Metadata {
+    type Error = String;
+
+    fn try_from(headers: &HeaderMap) -> Result<Self, Self::Error> {
+        let consensus_version = parse_required_header(headers, CONSENSUS_VERSION_HEADER, |s| {
+            s.parse::<ForkName>()
+                .map_err(|e| format!("invalid {CONSENSUS_VERSION_HEADER}: {e:?}"))
+        })?;
+        let consensus_block_value =
+            parse_required_header(headers, CONSENSUS_BLOCK_VALUE_HEADER, |s| {
+                Uint256::from_str_radix(s, 10)
+                    .map_err(|e| format!("invalid {CONSENSUS_BLOCK_VALUE_HEADER}: {e:?}"))
+            })?;
+
+        Ok(ProduceBlockV4Metadata {
+            consensus_version,
             consensus_block_value,
         })
     }

--- a/validator_client/beacon_node_fallback/src/lib.rs
+++ b/validator_client/beacon_node_fallback/src/lib.rs
@@ -1003,6 +1003,7 @@ mod tests {
             spec.clone(),
         );
 
+        // TODO(EIP-7732): discuss whether we should replace this with a new `mock_post_beacon__blocks_v2_ssz` for post-gloas blocks since no blinded blocks anymore.
         mock_beacon_node_1.mock_post_beacon_blinded_blocks_v2_ssz(Duration::from_secs(0));
         mock_beacon_node_2.mock_post_beacon_blinded_blocks_v2_ssz(Duration::from_secs(0));
 

--- a/validator_client/lighthouse_validator_store/src/lib.rs
+++ b/validator_client/lighthouse_validator_store/src/lib.rs
@@ -18,12 +18,12 @@ use task_executor::TaskExecutor;
 use tracing::{error, info, warn};
 use types::{
     AbstractExecPayload, Address, AggregateAndProof, Attestation, BeaconBlock, BlindedPayload,
-    ChainSpec, ContributionAndProof, Domain, Epoch, EthSpec, Fork, Graffiti, Hash256,
-    PublicKeyBytes, SelectionProof, Signature, SignedAggregateAndProof, SignedBeaconBlock,
-    SignedContributionAndProof, SignedRoot, SignedValidatorRegistrationData, SignedVoluntaryExit,
-    Slot, SyncAggregatorSelectionData, SyncCommitteeContribution, SyncCommitteeMessage,
-    SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData, VoluntaryExit,
-    graffiti::GraffitiString,
+    ChainSpec, ContributionAndProof, Domain, Epoch, EthSpec, ExecutionPayloadEnvelope, Fork,
+    Graffiti, Hash256, PublicKeyBytes, SelectionProof, Signature, SignedAggregateAndProof,
+    SignedBeaconBlock, SignedContributionAndProof, SignedExecutionPayloadEnvelope, SignedRoot,
+    SignedValidatorRegistrationData, SignedVoluntaryExit, Slot, SyncAggregatorSelectionData,
+    SyncCommitteeContribution, SyncCommitteeMessage, SyncSelectionProof, SyncSubnetId,
+    ValidatorRegistrationData, VoluntaryExit, graffiti::GraffitiString,
 };
 use validator_store::{
     DoppelgangerStatus, Error as ValidatorStoreError, ProposalData, SignedBlock, UnsignedBlock,
@@ -743,6 +743,45 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore for LighthouseValidatorS
                 .await
                 .map(|block| SignedBlock::Blinded(Arc::new(block))),
         }
+    }
+
+    async fn sign_block_gloas(
+        &self,
+        validator_pubkey: PublicKeyBytes,
+        block: &BeaconBlock<E>,
+        current_slot: Slot,
+    ) -> Result<Arc<SignedBeaconBlock<E>>, Error> {
+        let beacon_block = block.clone();
+        self.sign_abstract_block(validator_pubkey, beacon_block, current_slot)
+            .await
+            .map(|signed_block| Arc::new(signed_block))
+    }
+
+    async fn sign_execution_payload_envelope(
+        &self,
+        validator_pubkey: PublicKeyBytes,
+        envelope: &ExecutionPayloadEnvelope<E>,
+        current_slot: Slot,
+    ) -> Result<SignedExecutionPayloadEnvelope<E>, Error> {
+        let signing_epoch = current_slot.epoch(E::slots_per_epoch());
+        let signing_context = self.signing_context(Domain::BeaconBuilder, signing_epoch);
+
+        let signing_method = self.doppelganger_checked_signing_method(validator_pubkey)?;
+
+        let signature = signing_method
+            .get_signature::<E, BlindedPayload<E>>(
+                SignableMessage::ExecutionPayloadEnvelope(envelope),
+                signing_context,
+                &self.spec,
+                &self.task_executor,
+            )
+            .await
+            .map_err(Error::SpecificError)?;
+
+        let signed_envelope =
+            SignedExecutionPayloadEnvelope::from_envelope(envelope.clone(), signature);
+
+        Ok(signed_envelope)
     }
 
     async fn sign_attestation(

--- a/validator_client/signing_method/src/lib.rs
+++ b/validator_client/signing_method/src/lib.rs
@@ -47,6 +47,7 @@ pub enum SignableMessage<'a, E: EthSpec, Payload: AbstractExecPayload<E> = FullP
     SignedContributionAndProof(&'a ContributionAndProof<E>),
     ValidatorRegistration(&'a ValidatorRegistrationData),
     VoluntaryExit(&'a VoluntaryExit),
+    ExecutionPayloadEnvelope(&'a ExecutionPayloadEnvelope<E>),
 }
 
 impl<E: EthSpec, Payload: AbstractExecPayload<E>> SignableMessage<'_, E, Payload> {
@@ -68,6 +69,7 @@ impl<E: EthSpec, Payload: AbstractExecPayload<E>> SignableMessage<'_, E, Payload
             SignableMessage::SignedContributionAndProof(c) => c.signing_root(domain),
             SignableMessage::ValidatorRegistration(v) => v.signing_root(domain),
             SignableMessage::VoluntaryExit(exit) => exit.signing_root(domain),
+            SignableMessage::ExecutionPayloadEnvelope(envelope) => envelope.signing_root(domain),
         }
     }
 }
@@ -228,6 +230,9 @@ impl SigningMethod {
                         Web3SignerObject::ValidatorRegistration(v)
                     }
                     SignableMessage::VoluntaryExit(e) => Web3SignerObject::VoluntaryExit(e),
+                    SignableMessage::ExecutionPayloadEnvelope(envelope) => {
+                        Web3SignerObject::ExecutionPayloadEnvelope(envelope)
+                    }
                 };
 
                 // Determine the Web3Signer message type.

--- a/validator_client/signing_method/src/web3signer.rs
+++ b/validator_client/signing_method/src/web3signer.rs
@@ -18,6 +18,7 @@ pub enum MessageType {
     SyncCommitteeSelectionProof,
     SyncCommitteeContributionAndProof,
     ValidatorRegistration,
+    ExecutionPayloadEnvelope,
 }
 
 #[derive(Debug, PartialEq, Copy, Clone, Serialize)]
@@ -74,6 +75,7 @@ pub enum Web3SignerObject<'a, E: EthSpec, Payload: AbstractExecPayload<E>> {
     SyncAggregatorSelectionData(&'a SyncAggregatorSelectionData),
     ContributionAndProof(&'a ContributionAndProof<E>),
     ValidatorRegistration(&'a ValidatorRegistrationData),
+    ExecutionPayloadEnvelope(&'a ExecutionPayloadEnvelope<E>),
 }
 
 impl<'a, E: EthSpec, Payload: AbstractExecPayload<E>> Web3SignerObject<'a, E, Payload> {
@@ -139,6 +141,7 @@ impl<'a, E: EthSpec, Payload: AbstractExecPayload<E>> Web3SignerObject<'a, E, Pa
                 MessageType::SyncCommitteeContributionAndProof
             }
             Web3SignerObject::ValidatorRegistration(_) => MessageType::ValidatorRegistration,
+            Web3SignerObject::ExecutionPayloadEnvelope(_) => MessageType::ExecutionPayloadEnvelope,
         }
     }
 }

--- a/validator_client/validator_metrics/src/lib.rs
+++ b/validator_client/validator_metrics/src/lib.rs
@@ -9,6 +9,10 @@ pub const BEACON_BLOCK: &str = "beacon_block";
 pub const BEACON_BLOCK_HTTP_GET: &str = "beacon_block_http_get";
 pub const BEACON_BLOCK_HTTP_POST: &str = "beacon_block_http_post";
 pub const BLINDED_BEACON_BLOCK_HTTP_POST: &str = "blinded_beacon_block_http_post";
+pub const EXECUTION_PAYLOAD_ENVELOPE_HTTP_GET: &str = "execution_payload_envelope_http_get";
+pub const EXECUTION_PAYLOAD_ENVELOPE_HTTP_POST: &str = "execution_payload_envelope_http_post";
+pub const EXECUTION_PAYLOAD_ENVELOPE_SIGN: &str = "execution_payload_envelope_sign";
+pub const EXECUTION_PAYLOAD_ENVELOPE: &str = "execution_payload_envelope";
 pub const ATTESTATIONS: &str = "attestations";
 pub const ATTESTATIONS_HTTP_GET: &str = "attestations_http_get";
 pub const ATTESTATIONS_HTTP_POST: &str = "attestations_http_post";
@@ -235,6 +239,12 @@ pub static BLOCK_SIGNING_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
     try_create_histogram(
         "vc_block_signing_times_seconds",
         "Duration to obtain a signature for a block",
+    )
+});
+pub static ENVELOPE_SIGNING_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram(
+        "vc_envelope_signing_times_seconds",
+        "Duration to obtain a signature for an execution payload envelope",
     )
 });
 

--- a/validator_client/validator_services/src/block_service.rs
+++ b/validator_client/validator_services/src/block_service.rs
@@ -12,7 +12,9 @@ use std::time::Duration;
 use task_executor::TaskExecutor;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
-use types::{BlockType, ChainSpec, EthSpec, Graffiti, PublicKeyBytes, Slot};
+use types::{
+    BeaconBlock, BlockType, ChainSpec, EthSpec, Graffiti, PublicKeyBytes, SignedBeaconBlock, Slot,
+};
 use validator_store::{Error as ValidatorStoreError, SignedBlock, UnsignedBlock, ValidatorStore};
 
 #[derive(Debug)]
@@ -180,6 +182,41 @@ impl<T: SlotClock> ProposerFallback<T> {
             (Err(_), Some(proposer_nodes)) => proposer_nodes.first_success(func).await,
         }
     }
+
+    // Try `func` on `self.beacon_nodes` first. If that doesn't work, try `self.proposer_nodes`.
+    // Returns both the result and the beacon node client that provided it.
+    pub async fn request_proposers_last_with_source<F, O, Err, R>(
+        &self,
+        func: F,
+    ) -> Result<(O, BeaconNodeHttpClient), Errors<Err>>
+    where
+        F: Fn(BeaconNodeHttpClient) -> R + Clone,
+        R: Future<Output = Result<O, Err>>,
+        Err: Debug,
+    {
+        // Create a wrapper function that returns both the result and the source client
+        let wrapper_func = move |client: BeaconNodeHttpClient| {
+            let client_clone = client.clone();
+            let func_clone = func.clone();
+            async move {
+                func_clone(client)
+                    .await
+                    .map(|result| (result, client_clone))
+            }
+        };
+
+        // Try running wrapper_func on the non-proposer beacon nodes first
+        let beacon_nodes_result = self.beacon_nodes.first_success(wrapper_func.clone()).await;
+
+        match (beacon_nodes_result, &self.proposer_nodes) {
+            // The non-proposer node call succeeded, return the result and source.
+            (Ok(success), _) => Ok(success),
+            // The non-proposer node call failed, but we don't have any proposer nodes. Return an error.
+            (Err(e), None) => Err(e),
+            // The non-proposer node call failed, try the same call on the proposer nodes.
+            (Err(_), Some(proposer_nodes)) => proposer_nodes.first_success(wrapper_func).await,
+        }
+    }
 }
 
 /// Helper to minimise `Arc` usage.
@@ -290,6 +327,8 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
             )
         }
 
+        let current_epoch = slot.epoch(S::E::slots_per_epoch());
+
         for validator_pubkey in proposers {
             let builder_boost_factor = self
                 .validator_store
@@ -297,9 +336,15 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
             let service = self.clone();
             self.inner.executor.spawn(
                 async move {
-                    let result = service
+                    let result = if service.chain_spec.fork_name_at_epoch(current_epoch).gloas_enabled() {
+                      service
+                        .publish_block_gloas(slot, validator_pubkey, builder_boost_factor)
+                        .await }
+                      else {
+                        service
                         .publish_block(slot, validator_pubkey, builder_boost_factor)
-                        .await;
+                        .await
+                      };
 
                     match result {
                         Ok(_) => {}
@@ -389,6 +434,77 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
+    async fn sign_and_publish_block_gloas(
+        &self,
+        proposer_fallback: ProposerFallback<T>,
+        slot: Slot,
+        graffiti: Option<Graffiti>,
+        validator_pubkey: &PublicKeyBytes,
+        unsigned_block: &BeaconBlock<S::E>,
+    ) -> Result<(), BlockError> {
+        let signing_timer = validator_metrics::start_timer(&validator_metrics::BLOCK_SIGNING_TIMES);
+
+        let res = self
+            .validator_store
+            .sign_block_gloas(*validator_pubkey, unsigned_block, slot)
+            .await;
+
+        let signed_block = match res {
+            Ok(signed_block) => signed_block,
+            Err(ValidatorStoreError::UnknownPubkey(pubkey)) => {
+                // A pubkey can be missing when a validator was recently removed
+                // via the API.
+                warn!(
+                    info = "a validator may have recently been removed from this VC",
+                    ?pubkey,
+                    ?slot,
+                    "Missing pubkey for block"
+                );
+                return Ok(());
+            }
+            Err(e) => {
+                return Err(BlockError::Recoverable(format!(
+                    "Unable to sign block: {e:?}"
+                )));
+            }
+        };
+
+        let signing_time_ms =
+            Duration::from_secs_f64(signing_timer.map_or(0.0, |t| t.stop_and_record())).as_millis();
+
+        info!(
+            slot = slot.as_u64(),
+            signing_time_ms = signing_time_ms,
+            "Publishing signed block"
+        );
+
+        // Publish block with first available beacon node.
+        //
+        // Try the proposer nodes first, since we've likely gone to efforts to
+        // protect them from DoS attacks and they're most likely to successfully
+        // publish a block.
+        proposer_fallback
+            .request_proposers_first(|beacon_node| async {
+                self.publish_signed_block_contents_gloas(&signed_block, beacon_node)
+                    .await
+            })
+            .await?;
+
+        let metadata = BlockMetadata::from(&signed_block);
+        info!(
+            block_type = ?metadata.block_type,
+            deposits = metadata.num_deposits,
+            attestations = metadata.num_attestations,
+            graffiti = ?graffiti.map(|g| g.as_utf8_lossy()),
+            slot = metadata.slot.as_u64(),
+            "Successfully published block"
+        );
+        Ok(())
+    }
+
+    // TODO(EIP-7732): Remove this sometime after gloas is live and make publish_block_gloas the default
+    // TODO(EIP-7732): Seems like block production testing is done through `simulator`. Discuss with team if that is sufficient for all this new gloas code.
     async fn publish_block(
         self,
         slot: Slot,
@@ -483,6 +599,125 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
         Ok(())
     }
 
+    async fn publish_block_gloas(
+        self,
+        slot: Slot,
+        validator_pubkey: PublicKeyBytes,
+        builder_boost_factor: Option<u64>,
+    ) -> Result<(), BlockError> {
+        let timer = validator_metrics::start_timer_vec(
+            &validator_metrics::BLOCK_SERVICE_TIMES,
+            &[validator_metrics::BEACON_BLOCK],
+        );
+
+        let randao_reveal = match self
+            .validator_store
+            .randao_reveal(validator_pubkey, slot.epoch(S::E::slots_per_epoch()))
+            .await
+        {
+            Ok(signature) => signature.into(),
+            Err(ValidatorStoreError::UnknownPubkey(pubkey)) => {
+                // A pubkey can be missing when a validator was recently removed
+                // via the API.
+                warn!(
+                    info = "a validator may have recently been removed from this VC",
+                    ?pubkey,
+                    ?slot,
+                    "Missing pubkey for block randao"
+                );
+                return Ok(());
+            }
+            Err(e) => {
+                return Err(BlockError::Recoverable(format!(
+                    "Unable to produce randao reveal signature: {:?}",
+                    e
+                )));
+            }
+        };
+
+        let graffiti = determine_graffiti(
+            &validator_pubkey,
+            self.graffiti_file.clone(),
+            self.validator_store.graffiti(&validator_pubkey),
+            self.graffiti,
+        );
+
+        let randao_reveal_ref = &randao_reveal;
+        let self_ref = &self;
+        let proposer_index = self.validator_store.validator_index(&validator_pubkey);
+        let proposer_fallback = ProposerFallback {
+            beacon_nodes: self.beacon_nodes.clone(),
+            proposer_nodes: self.proposer_nodes.clone(),
+        };
+
+        info!(slot = slot.as_u64(), "Requesting unsigned block");
+
+        // Request block from first responsive beacon node.
+        //
+        // IMPORTANT: We use request_proposers_last_with_source here to track which
+        // beacon node provided the block. This is critical for Gloas because the
+        // ExecutionPayloadEnvelope must come from the same beacon node that built
+        // the block (only that node will have the envelope cached).
+        let (unsigned_block, block_source_node) = proposer_fallback
+            .request_proposers_last_with_source(|beacon_node| async move {
+                let _get_timer = validator_metrics::start_timer_vec(
+                    &validator_metrics::BLOCK_SERVICE_TIMES,
+                    &[validator_metrics::BEACON_BLOCK_HTTP_GET],
+                );
+                Self::get_validator_block_gloas(
+                    &beacon_node,
+                    slot,
+                    randao_reveal_ref,
+                    graffiti,
+                    proposer_index,
+                    builder_boost_factor,
+                )
+                .await
+                .map_err(|e| {
+                    BlockError::Recoverable(format!(
+                        "Error from beacon node when producing block: {:?}",
+                        e
+                    ))
+                })
+            })
+            .await?;
+
+        self_ref
+            .sign_and_publish_block_gloas(
+                proposer_fallback,
+                slot,
+                graffiti,
+                &validator_pubkey,
+                &unsigned_block,
+            )
+            .await?;
+
+        drop(timer);
+
+        // Check if this validator is also the builder for this block. If so, publish envelope
+        if let (Ok(bid), Some(validator_idx)) = (
+            unsigned_block.body().signed_execution_payload_bid(),
+            self_ref.validator_store.validator_index(&validator_pubkey),
+        ) {
+            if bid.message.builder_index == validator_idx {
+                info!(
+                    validator_index = validator_idx,
+                    builder_index = bid.message.builder_index,
+                    "Proposer is also the builder, will publish execution payload envelope after block"
+                );
+                self_ref
+                    .publish_execution_payload_envelope(
+                        slot,
+                        validator_pubkey,
+                        Some(block_source_node),
+                    )
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
     async fn publish_signed_block_contents(
         &self,
         signed_block: &SignedBlock<S::E>,
@@ -516,6 +751,62 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
             }
         }
         Ok::<_, BlockError>(())
+    }
+
+    async fn publish_signed_block_contents_gloas(
+        &self,
+        signed_block: &Arc<SignedBeaconBlock<S::E>>,
+        beacon_node: BeaconNodeHttpClient,
+    ) -> Result<(), BlockError> {
+        let _post_timer = validator_metrics::start_timer_vec(
+            &validator_metrics::BLOCK_SERVICE_TIMES,
+            &[validator_metrics::BEACON_BLOCK_HTTP_POST],
+        );
+        let publish_request = eth2::types::PublishBlockRequest::Block(signed_block.clone());
+        beacon_node
+            .post_beacon_blocks_v2_ssz(&publish_request, None)
+            .await
+            .map(|_| ())
+            .or_else(|e| handle_block_post_error(e, signed_block.message().slot()))?;
+        Ok(())
+    }
+
+    async fn publish_signed_envelope_contents(
+        &self,
+        signed_envelope: &types::SignedExecutionPayloadEnvelope<S::E>,
+        slot: Slot,
+    ) -> Result<(), BlockError> {
+        let _post_timer = validator_metrics::start_timer_vec(
+            &validator_metrics::BLOCK_SERVICE_TIMES,
+            &[validator_metrics::EXECUTION_PAYLOAD_ENVELOPE_HTTP_POST],
+        );
+
+        let proposer_fallback = ProposerFallback {
+            beacon_nodes: self.beacon_nodes.clone(),
+            proposer_nodes: self.proposer_nodes.clone(),
+        };
+
+        // Publish envelope with first available beacon node.
+        // Try the proposer nodes first, since we've likely gone to efforts to
+        // protect them from DoS attacks and they're most likely to successfully
+        // publish an envelope.
+        let fork_name = self.chain_spec.fork_name_at_slot::<S::E>(slot);
+
+        proposer_fallback
+            .request_proposers_first(|beacon_node| async move {
+                beacon_node
+                    .post_execution_payload_envelope_ssz(signed_envelope, fork_name)
+                    .await
+                    .map_err(|e| {
+                        BlockError::Recoverable(format!(
+                            "Error from beacon node when publishing execution payload envelope: {:?}",
+                            e
+                        ))
+                    })
+            })
+            .await?;
+
+        Ok(())
     }
 
     async fn get_validator_block(
@@ -581,6 +872,208 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
 
         Ok::<_, BlockError>(unsigned_block)
     }
+
+    async fn get_validator_block_gloas(
+        beacon_node: &BeaconNodeHttpClient,
+        slot: Slot,
+        randao_reveal_ref: &SignatureBytes,
+        graffiti: Option<Graffiti>,
+        proposer_index: Option<u64>,
+        builder_boost_factor: Option<u64>,
+    ) -> Result<BeaconBlock<S::E>, BlockError> {
+        let unsigned_block = match beacon_node
+            .get_validator_blocks_v4_ssz::<S::E>(
+                slot,
+                randao_reveal_ref,
+                graffiti.as_ref(),
+                builder_boost_factor,
+            )
+            .await
+        {
+            Ok((ssz_block_response, _)) => ssz_block_response,
+            Err(e) => {
+                warn!(
+                    slot = slot.as_u64(),
+                    error = %e,
+                    "Beacon node does not support SSZ in v4 block production, falling back to JSON"
+                );
+
+                let (json_block_response, _) = beacon_node
+                    .get_validator_blocks_v4::<S::E>(
+                        slot,
+                        randao_reveal_ref,
+                        graffiti.as_ref(),
+                        builder_boost_factor,
+                    )
+                    .await
+                    .map_err(|e| {
+                        BlockError::Recoverable(format!(
+                            "Error from beacon node when producing v4 block: {:?}",
+                            e
+                        ))
+                    })?;
+
+                // Extract BeaconBlock (data field of the struct ForkVersionedResponse)
+                json_block_response.data
+            }
+        };
+
+        let block_proposer = unsigned_block.proposer_index();
+
+        info!(slot = slot.as_u64(), "Received unsigned v4 block");
+        if proposer_index != Some(block_proposer) {
+            return Err(BlockError::Recoverable(
+                "Proposer index does not match block proposer. Beacon chain re-orged".to_string(),
+            ));
+        }
+
+        Ok::<_, BlockError>(unsigned_block)
+    }
+
+    async fn sign_execution_payload_envelope(
+        &self,
+        envelope: &types::ExecutionPayloadEnvelope<S::E>,
+        validator_pubkey: PublicKeyBytes,
+        slot: Slot,
+    ) -> Result<types::SignedExecutionPayloadEnvelope<S::E>, BlockError> {
+        let envelope_signing_timer =
+            validator_metrics::start_timer(&validator_metrics::ENVELOPE_SIGNING_TIMES);
+
+        info!(
+            slot = slot.as_u64(),
+            pub_key = %validator_pubkey,
+            "Signing execution payload envelope using ValidatorStore"
+        );
+
+        let signed_envelope = self
+            .validator_store
+            .sign_execution_payload_envelope(validator_pubkey, envelope, slot)
+            .await
+            .map_err(|e| {
+                BlockError::Irrecoverable(format!(
+                    "Failed to sign execution payload envelope: {:?}",
+                    e
+                ))
+            })?;
+
+        let envelope_signing_time_ms =
+            Duration::from_secs_f64(envelope_signing_timer.map_or(0.0, |t| t.stop_and_record()))
+                .as_millis();
+
+        info!(
+            slot = slot.as_u64(),
+            envelope_signing_time_ms = envelope_signing_time_ms,
+            pub_key = %validator_pubkey,
+            "Successfully signed execution payload envelope"
+        );
+
+        Ok(signed_envelope)
+    }
+
+    async fn get_execution_payload_envelope(
+        &self,
+        slot: Slot,
+        validator_pubkey: &PublicKeyBytes,
+        source_beacon_node: Option<BeaconNodeHttpClient>,
+    ) -> Result<types::ExecutionPayloadEnvelope<S::E>, BlockError> {
+        let _timer = validator_metrics::start_timer_vec(
+            &validator_metrics::BLOCK_SERVICE_TIMES,
+            &[validator_metrics::EXECUTION_PAYLOAD_ENVELOPE_HTTP_GET],
+        );
+
+        let builder_index = match self.validator_store.validator_index(validator_pubkey) {
+            Some(index) => index,
+            None => {
+                return Err(BlockError::Irrecoverable(format!(
+                    "Cannot find validator index {} for execution payload envelope",
+                    validator_pubkey
+                )));
+            }
+        };
+
+        // CRITICAL: We MUST use the same beacon node that provided the block.
+        // Only that beacon node will have the corresponding ExecutionPayloadEnvelope
+        // cached. If we don't have the source beacon node, this will fail.
+        let beacon_node = source_beacon_node.ok_or_else(|| {
+            BlockError::Irrecoverable(
+                "Cannot get execution payload envelope: no source beacon node available. \
+                 The ExecutionPayloadEnvelope must come from the same beacon node that built the block."
+                    .to_string(),
+            )
+        })?;
+
+        info!(
+            slot = slot.as_u64(),
+            pub_key = %validator_pubkey,
+            "Getting execution payload envelope from same beacon node that provided the block"
+        );
+
+        // Try SSZ first, fallback to JSON if it fails
+        match beacon_node
+            .get_execution_payload_envelope_ssz::<S::E>(slot, builder_index)
+            .await
+        {
+            Ok(envelope) => Ok(envelope),
+            Err(e) => {
+                warn!(
+                    slot = slot.as_u64(),
+                    error = %e,
+                    "Beacon node does not support SSZ for execution payload envelope, falling back to JSON"
+                );
+
+                let json_response = beacon_node
+                    .get_execution_payload_envelope::<S::E>(slot, builder_index)
+                    .await
+                    .map_err(|e| {
+                        BlockError::Recoverable(format!(
+                            "Error getting execution payload envelope from source beacon node: {:?}",
+                            e
+                        ))
+                    })?;
+
+                Ok(json_response.data)
+            }
+        }
+    }
+
+    async fn publish_execution_payload_envelope(
+        &self,
+        slot: Slot,
+        validator_pubkey: PublicKeyBytes,
+        source_beacon_node: Option<BeaconNodeHttpClient>,
+    ) -> Result<(), BlockError> {
+        let _timer = validator_metrics::start_timer_vec(
+            &validator_metrics::BLOCK_SERVICE_TIMES,
+            &[validator_metrics::EXECUTION_PAYLOAD_ENVELOPE],
+        );
+
+        info!(slot = slot.as_u64(), pub_key = %validator_pubkey, "Submitting payload envelope");
+
+        let envelope = self
+            .get_execution_payload_envelope(slot, &validator_pubkey, source_beacon_node)
+            .await?;
+
+        let signed_envelope = self
+            .sign_execution_payload_envelope(&envelope, validator_pubkey, slot)
+            .await?;
+
+        info!(
+            ?slot,
+            pub_key = %validator_pubkey,
+            "Successfully signed execution payload envelope"
+        );
+
+        self.publish_signed_envelope_contents(&signed_envelope, slot)
+            .await?;
+
+        info!(
+            ?slot,
+            pub_key = %validator_pubkey,
+            "Successfully published execution payload envelope"
+        );
+
+        Ok(())
+    }
 }
 
 /// Wrapper for values we want to log about a block we signed, for easy extraction from the possible
@@ -607,6 +1100,17 @@ impl<E: EthSpec> From<&SignedBlock<E>> for BlockMetadata {
                 num_deposits: block.message().body().deposits().len(),
                 num_attestations: block.message().body().attestations_len(),
             },
+        }
+    }
+}
+
+impl<E: EthSpec> From<&Arc<SignedBeaconBlock<E>>> for BlockMetadata {
+    fn from(block: &Arc<SignedBeaconBlock<E>>) -> Self {
+        Self {
+            block_type: BlockType::Full,
+            slot: block.message().slot(),
+            num_deposits: block.message().body().deposits().len(),
+            num_attestations: block.message().body().attestations_len(),
         }
     }
 }

--- a/validator_client/validator_store/src/lib.rs
+++ b/validator_client/validator_store/src/lib.rs
@@ -4,10 +4,12 @@ use std::fmt::Debug;
 use std::future::Future;
 use std::sync::Arc;
 use types::{
-    Address, Attestation, AttestationError, BlindedBeaconBlock, Epoch, EthSpec, Graffiti, Hash256,
-    PublicKeyBytes, SelectionProof, Signature, SignedAggregateAndProof, SignedBlindedBeaconBlock,
-    SignedContributionAndProof, SignedValidatorRegistrationData, Slot, SyncCommitteeContribution,
-    SyncCommitteeMessage, SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData,
+    Address, Attestation, AttestationError, BeaconBlock, BlindedBeaconBlock, Epoch, EthSpec,
+    ExecutionPayloadEnvelope, Graffiti, Hash256, PublicKeyBytes, SelectionProof, Signature,
+    SignedAggregateAndProof, SignedBeaconBlock, SignedBlindedBeaconBlock,
+    SignedContributionAndProof, SignedExecutionPayloadEnvelope, SignedValidatorRegistrationData,
+    Slot, SyncCommitteeContribution, SyncCommitteeMessage, SyncSelectionProof, SyncSubnetId,
+    ValidatorRegistrationData,
 };
 
 #[derive(Debug, PartialEq, Clone)]
@@ -101,6 +103,20 @@ pub trait ValidatorStore: Send + Sync {
         block: UnsignedBlock<Self::E>,
         current_slot: Slot,
     ) -> impl Future<Output = Result<SignedBlock<Self::E>, Error<Self::Error>>> + Send;
+
+    fn sign_block_gloas(
+        &self,
+        validator_pubkey: PublicKeyBytes,
+        block: &BeaconBlock<Self::E>,
+        current_slot: Slot,
+    ) -> impl Future<Output = Result<Arc<SignedBeaconBlock<Self::E>>, Error<Self::Error>>> + Send;
+
+    fn sign_execution_payload_envelope(
+        &self,
+        validator_pubkey: PublicKeyBytes,
+        envelope: &ExecutionPayloadEnvelope<Self::E>,
+        current_slot: Slot,
+    ) -> impl Future<Output = Result<SignedExecutionPayloadEnvelope<Self::E>, Error<Self::Error>>> + Send;
 
     fn sign_attestation(
         &self,


### PR DESCRIPTION
## Changes
- added VC side block production flow for gloas to support self-building for the devnet-0 release, per [spec](https://ethereum.github.io/consensus-specs/specs/gloas/validator/#block-proposal)

## How This Works
In Gloas, the `publish_block` flow in the VC is modified to add the get, sign, and publish of a payload envelope, which occus when the `BeaconBlock.body.signed_execution_payload_bid.message.builder_index` is the same as the proposer's validator index.

Additionally, when requesting a block from the BN, we will no longer receive blobs or kzg commitments.  Instead, payload envelopes and blobs will be released by the proposer in the self-building scenario or otherwise by the in-protocol builder.  There is no longer a concept of requesting unblinded or blinded blocks since all CL blocks just contain bids. 

Client-side endpoints were added to support requesting gloas block and additionally envelopes.  All the new and modified epbs beacon api endpoints are defined in [PR](https://github.com/ethereum/beacon-APIs/pull/552).

## Todo's (left comments in the code as well)
- the server side (BN) response to the api's modified and added in this PR will need to be handled since we're only touching the VC in this PR. This is contingent on the upcoming `envelope_verification.rs` flow since we request an envelope to sign and gossip during block production.  Additionally, the `produce_block` call to the BN will no longer respond with blobs for example, so we'll need to modify this endpoint.  Additionally, the BN endpoint that receives the signed block to broadcast flow will need to be modified as well.
- add tests for `produce_block_v4` and other new endpoints on the server side
