### PR TITLE
ExecutionPayloadEnvelopesByRoot boilerplate

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -116,6 +116,7 @@ pub struct BeaconProcessorQueueLengths {
     rpc_blob_queue: usize,
     rpc_custody_column_queue: usize,
     envelope_range_queue: usize,
+    envelope_root_queue: usize,
     column_reconstruction_queue: usize,
     chain_segment_queue: usize,
     backfill_chain_segment: usize,
@@ -183,6 +184,7 @@ impl BeaconProcessorQueueLengths {
             // this queue size. With 48 max blobs per block, each column sidecar list could be up to 12MB.
             rpc_custody_column_queue: 64,
             envelope_range_queue: 1024,
+            envelope_root_queue: 1024,
             column_reconstruction_queue: 64,
             chain_segment_queue: 64,
             backfill_chain_segment: 64,
@@ -614,6 +616,7 @@ pub enum Work<E: EthSpec> {
     DataColumnsByRootsRequest(BlockingFn),
     DataColumnsByRangeRequest(BlockingFn),
     ExecutionPayloadEnvelopesByRangeRequest(BlockingFn),
+    ExecutionPayloadEnvelopesByRootRequest(BlockingFn),
     GossipBlsToExecutionChange(BlockingFn),
     LightClientBootstrapRequest(BlockingFn),
     LightClientOptimisticUpdateRequest(BlockingFn),
@@ -667,6 +670,7 @@ pub enum WorkType {
     DataColumnsByRootsRequest,
     DataColumnsByRangeRequest,
     ExecutionPayloadEnvelopesByRangeRequest,
+    ExecutionPayloadEnvelopesByRootRequest,
     GossipBlsToExecutionChange,
     LightClientBootstrapRequest,
     LightClientOptimisticUpdateRequest,
@@ -719,6 +723,9 @@ impl<E: EthSpec> Work<E> {
             Work::DataColumnsByRangeRequest(_) => WorkType::DataColumnsByRangeRequest,
             Work::ExecutionPayloadEnvelopesByRangeRequest(_) => {
                 WorkType::ExecutionPayloadEnvelopesByRangeRequest
+            }
+            Work::ExecutionPayloadEnvelopesByRootRequest(_) => {
+                WorkType::ExecutionPayloadEnvelopesByRootRequest
             }
             Work::LightClientBootstrapRequest(_) => WorkType::LightClientBootstrapRequest,
             Work::LightClientOptimisticUpdateRequest(_) => {
@@ -874,6 +881,7 @@ impl<E: EthSpec> BeaconProcessor<E> {
         let mut rpc_blob_queue = FifoQueue::new(queue_lengths.rpc_blob_queue);
         let mut rpc_custody_column_queue = FifoQueue::new(queue_lengths.rpc_custody_column_queue);
         let mut envelope_range_queue = FifoQueue::new(queue_lengths.envelope_range_queue);
+        let mut envelope_root_queue = FifoQueue::new(queue_lengths.envelope_root_queue);
         let mut column_reconstruction_queue =
             FifoQueue::new(queue_lengths.column_reconstruction_queue);
         let mut chain_segment_queue = FifoQueue::new(queue_lengths.chain_segment_queue);
@@ -1407,6 +1415,9 @@ impl<E: EthSpec> BeaconProcessor<E> {
                             Work::ExecutionPayloadEnvelopesByRangeRequest { .. } => {
                                 envelope_range_queue.push(work, work_id)
                             }
+                            Work::ExecutionPayloadEnvelopesByRootRequest { .. } => {
+                                envelope_root_queue.push(work, work_id)
+                            }
                             Work::UnknownLightClientOptimisticUpdate { .. } => {
                                 unknown_light_client_update_queue.push(work, work_id)
                             }
@@ -1459,6 +1470,9 @@ impl<E: EthSpec> BeaconProcessor<E> {
                         WorkType::DataColumnsByRangeRequest => dcbrange_queue.len(),
                         WorkType::ExecutionPayloadEnvelopesByRangeRequest => {
                             envelope_range_queue.len()
+                        }
+                        WorkType::ExecutionPayloadEnvelopesByRootRequest => {
+                            envelope_root_queue.len()
                         }
                         WorkType::GossipBlsToExecutionChange => {
                             gossip_bls_to_execution_change_queue.len()
@@ -1637,6 +1651,7 @@ impl<E: EthSpec> BeaconProcessor<E> {
             | Work::Status(process_fn)
             | Work::GossipBlsToExecutionChange(process_fn)
             | Work::ExecutionPayloadEnvelopesByRangeRequest(process_fn)
+            | Work::ExecutionPayloadEnvelopesByRootRequest(process_fn)
             | Work::LightClientBootstrapRequest(process_fn)
             | Work::LightClientOptimisticUpdateRequest(process_fn)
             | Work::LightClientFinalityUpdateRequest(process_fn)

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -587,6 +587,7 @@ impl<E: EthSpec> PeerManager<E> {
                     Protocol::DataColumnsByRoot => PeerAction::MidToleranceError,
                     Protocol::DataColumnsByRange => PeerAction::MidToleranceError,
                     Protocol::ExecutionPayloadEnvelopesByRange => PeerAction::MidToleranceError,
+                    Protocol::ExecutionPayloadEnvelopesByRoot => PeerAction::MidToleranceError,
                     // Lighthouse does not currently make light client requests; therefore, this
                     // is an unexpected scenario. We do not ban the peer for rate limiting.
                     Protocol::LightClientBootstrap => return,
@@ -614,6 +615,7 @@ impl<E: EthSpec> PeerManager<E> {
                     Protocol::DataColumnsByRoot => return,
                     Protocol::DataColumnsByRange => return,
                     Protocol::ExecutionPayloadEnvelopesByRange => return,
+                    Protocol::ExecutionPayloadEnvelopesByRoot => return,
                     Protocol::Goodbye => return,
                     Protocol::LightClientBootstrap => return,
                     Protocol::LightClientOptimisticUpdate => return,
@@ -638,6 +640,7 @@ impl<E: EthSpec> PeerManager<E> {
                     Protocol::DataColumnsByRoot => PeerAction::MidToleranceError,
                     Protocol::DataColumnsByRange => PeerAction::MidToleranceError,
                     Protocol::ExecutionPayloadEnvelopesByRange => PeerAction::MidToleranceError,
+                    Protocol::ExecutionPayloadEnvelopesByRoot => PeerAction::MidToleranceError,
                     Protocol::LightClientBootstrap => return,
                     Protocol::LightClientOptimisticUpdate => return,
                     Protocol::LightClientFinalityUpdate => return,

--- a/beacon_node/lighthouse_network/src/rpc/codec.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec.rs
@@ -82,6 +82,7 @@ impl<E: EthSpec> SSZSnappyInboundCodec<E> {
                 RpcSuccessResponse::DataColumnsByRoot(res) => res.as_ssz_bytes(),
                 RpcSuccessResponse::DataColumnsByRange(res) => res.as_ssz_bytes(),
                 RpcSuccessResponse::ExecutionPayloadEnvelopesByRange(res) => res.as_ssz_bytes(),
+                RpcSuccessResponse::ExecutionPayloadEnvelopesByRoot(res) => res.as_ssz_bytes(),
                 RpcSuccessResponse::LightClientBootstrap(res) => res.as_ssz_bytes(),
                 RpcSuccessResponse::LightClientOptimisticUpdate(res) => res.as_ssz_bytes(),
                 RpcSuccessResponse::LightClientFinalityUpdate(res) => res.as_ssz_bytes(),
@@ -363,6 +364,7 @@ impl<E: EthSpec> Encoder<RequestType<E>> for SSZSnappyOutboundCodec<E> {
             RequestType::DataColumnsByRange(req) => req.as_ssz_bytes(),
             RequestType::DataColumnsByRoot(req) => req.data_column_ids.as_ssz_bytes(),
             RequestType::ExecutionPayloadEnvelopesByRange(req) => req.as_ssz_bytes(),
+            RequestType::ExecutionPayloadEnvelopesByRoot(req) => req.block_roots.as_ssz_bytes(),
             RequestType::Ping(req) => req.as_ssz_bytes(),
             RequestType::LightClientBootstrap(req) => req.as_ssz_bytes(),
             RequestType::LightClientUpdatesByRange(req) => req.as_ssz_bytes(),
@@ -576,6 +578,14 @@ fn handle_rpc_request<E: EthSpec>(
                 ExecutionPayloadEnvelopesByRangeRequest::from_ssz_bytes(decoded_buffer)?,
             )))
         }
+        SupportedProtocol::ExecutionPayloadEnvelopesByRootV1 => Ok(Some(
+            RequestType::ExecutionPayloadEnvelopesByRoot(ExecutionPayloadEnvelopesByRootRequest {
+                block_roots: <RuntimeVariableList<Hash256>>::from_ssz_bytes(
+                    decoded_buffer,
+                    spec.max_request_payloads as usize,
+                )?,
+            }),
+        )),
         SupportedProtocol::PingV1 => Ok(Some(RequestType::Ping(Ping {
             data: u64::from_ssz_bytes(decoded_buffer)?,
         }))),
@@ -751,6 +761,29 @@ fn handle_rpc_response<E: EthSpec>(
                     Err(RPCError::ErrorResponse(
                         RpcErrorResponse::InvalidRequest,
                         "Invalid fork name for execution payload envelopes by range".to_string(),
+                    ))
+                }
+            }
+            None => Err(RPCError::ErrorResponse(
+                RpcErrorResponse::InvalidRequest,
+                format!(
+                    "No context bytes provided for {:?} response",
+                    versioned_protocol
+                ),
+            )),
+        },
+        SupportedProtocol::ExecutionPayloadEnvelopesByRootV1 => match fork_name {
+            Some(fork_name) => {
+                if fork_name.gloas_enabled() {
+                    Ok(Some(RpcSuccessResponse::ExecutionPayloadEnvelopesByRoot(
+                        Arc::new(SignedExecutionPayloadEnvelope::Gloas(
+                            SignedExecutionPayloadEnvelopeGloas::from_ssz_bytes(decoded_buffer)?,
+                        )),
+                    )))
+                } else {
+                    Err(RPCError::ErrorResponse(
+                        RpcErrorResponse::InvalidRequest,
+                        "Invalid fork name for execution payload envelopes by root".to_string(),
                     ))
                 }
             }

--- a/beacon_node/lighthouse_network/src/rpc/config.rs
+++ b/beacon_node/lighthouse_network/src/rpc/config.rs
@@ -98,6 +98,7 @@ pub struct RateLimiterConfig {
     pub(super) light_client_finality_update_quota: Quota,
     pub(super) light_client_updates_by_range_quota: Quota,
     pub(super) execution_payload_envelopes_by_range_quota: Quota,
+    pub(super) execution_payload_envelopes_by_root_quota: Quota,
 }
 
 impl RateLimiterConfig {
@@ -131,6 +132,10 @@ impl RateLimiterConfig {
     // TODO(EIP-7732): see if team supports this config
     pub const DEFAULT_EXECUTION_PAYLOAD_ENVELOPES_BY_RANGE_QUOTA: Quota =
         Quota::n_every(NonZeroU64::new(128).unwrap(), 10);
+    // Allow up to MAX_REQUEST_PAYLOADS (128) payload envelopes per request
+    // TODO(EIP-7732): see if team supports this config
+    pub const DEFAULT_EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT_QUOTA: Quota =
+        Quota::n_every(NonZeroU64::new(128).unwrap(), 10);
 }
 
 impl Default for RateLimiterConfig {
@@ -153,6 +158,8 @@ impl Default for RateLimiterConfig {
             light_client_updates_by_range_quota: Self::DEFAULT_LIGHT_CLIENT_UPDATES_BY_RANGE_QUOTA,
             execution_payload_envelopes_by_range_quota:
                 Self::DEFAULT_EXECUTION_PAYLOAD_ENVELOPES_BY_RANGE_QUOTA,
+            execution_payload_envelopes_by_root_quota:
+                Self::DEFAULT_EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT_QUOTA,
         }
     }
 }
@@ -186,6 +193,14 @@ impl Debug for RateLimiterConfig {
                 "data_columns_by_root",
                 fmt_q!(&self.data_columns_by_root_quota),
             )
+            .field(
+                "execution_payload_envelopes_by_range",
+                fmt_q!(&self.execution_payload_envelopes_by_range_quota),
+            )
+            .field(
+                "execution_payload_envelopes_by_root",
+                fmt_q!(&self.execution_payload_envelopes_by_root_quota),
+            )
             .finish()
     }
 }
@@ -213,6 +228,7 @@ impl FromStr for RateLimiterConfig {
         let mut light_client_finality_update_quota = None;
         let mut light_client_updates_by_range_quota = None;
         let mut execution_payload_envelopes_by_range_quota = None;
+        let mut execution_payload_envelopes_by_root_quota = None;
 
         for proto_def in s.split(';') {
             let ProtocolQuota { protocol, quota } = proto_def.parse()?;
@@ -251,6 +267,10 @@ impl FromStr for RateLimiterConfig {
                     execution_payload_envelopes_by_range_quota =
                         execution_payload_envelopes_by_range_quota.or(quota)
                 }
+                Protocol::ExecutionPayloadEnvelopesByRoot => {
+                    execution_payload_envelopes_by_root_quota =
+                        execution_payload_envelopes_by_root_quota.or(quota)
+                }
             }
         }
         Ok(RateLimiterConfig {
@@ -279,6 +299,8 @@ impl FromStr for RateLimiterConfig {
                 .unwrap_or(Self::DEFAULT_LIGHT_CLIENT_UPDATES_BY_RANGE_QUOTA),
             execution_payload_envelopes_by_range_quota: execution_payload_envelopes_by_range_quota
                 .unwrap_or(Self::DEFAULT_EXECUTION_PAYLOAD_ENVELOPES_BY_RANGE_QUOTA),
+            execution_payload_envelopes_by_root_quota: execution_payload_envelopes_by_root_quota
+                .unwrap_or(Self::DEFAULT_EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT_QUOTA),
         })
     }
 }

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -426,6 +426,21 @@ impl ExecutionPayloadEnvelopesByRangeRequest {
     }
 }
 
+/// Request execution payload envelopes by their block roots.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExecutionPayloadEnvelopesByRootRequest {
+    /// The list of beacon block roots being requested.
+    pub block_roots: RuntimeVariableList<Hash256>,
+}
+
+impl ExecutionPayloadEnvelopesByRootRequest {
+    pub fn new(block_roots: Vec<Hash256>, max_request_payloads: usize) -> Result<Self, String> {
+        let block_roots = RuntimeVariableList::new(block_roots, max_request_payloads)
+            .map_err(|e| format!("ExecutionPayloadEnvelopesByRootRequest too many roots: {e:?}"))?;
+        Ok(Self { block_roots })
+    }
+}
+
 /// Request a number of beacon block roots from a peer.
 #[superstruct(
     variants(V1, V2),
@@ -616,6 +631,9 @@ pub enum RpcSuccessResponse<E: EthSpec> {
     /// A response to a get EXECUTION_PAYLOAD_ENVELOPES_BY_RANGE request.
     ExecutionPayloadEnvelopesByRange(Arc<SignedExecutionPayloadEnvelope<E>>),
 
+    /// A response to a get EXECUTION_PAYLOAD_ENVELOPES_BY_ROOT request.
+    ExecutionPayloadEnvelopesByRoot(Arc<SignedExecutionPayloadEnvelope<E>>),
+
     /// A response to a get BLOBS_BY_ROOT request.
     BlobsByRoot(Arc<BlobSidecar<E>>),
 
@@ -658,6 +676,9 @@ pub enum ResponseTermination {
 
     /// Execution payload envelopes by range stream termination.
     ExecutionPayloadEnvelopesByRange,
+
+    /// Execution payload envelopes by root stream termination.
+    ExecutionPayloadEnvelopesByRoot,
 }
 
 impl ResponseTermination {
@@ -672,6 +693,9 @@ impl ResponseTermination {
             ResponseTermination::LightClientUpdatesByRange => Protocol::LightClientUpdatesByRange,
             ResponseTermination::ExecutionPayloadEnvelopesByRange => {
                 Protocol::ExecutionPayloadEnvelopesByRange
+            }
+            ResponseTermination::ExecutionPayloadEnvelopesByRoot => {
+                Protocol::ExecutionPayloadEnvelopesByRoot
             }
         }
     }
@@ -770,6 +794,9 @@ impl<E: EthSpec> RpcSuccessResponse<E> {
             RpcSuccessResponse::ExecutionPayloadEnvelopesByRange(_) => {
                 Protocol::ExecutionPayloadEnvelopesByRange
             }
+            RpcSuccessResponse::ExecutionPayloadEnvelopesByRoot(_) => {
+                Protocol::ExecutionPayloadEnvelopesByRoot
+            }
             RpcSuccessResponse::Pong(_) => Protocol::Ping,
             RpcSuccessResponse::MetaData(_) => Protocol::MetaData,
             RpcSuccessResponse::LightClientBootstrap(_) => Protocol::LightClientBootstrap,
@@ -791,6 +818,7 @@ impl<E: EthSpec> RpcSuccessResponse<E> {
                 Some(r.signed_block_header.message.slot)
             }
             Self::ExecutionPayloadEnvelopesByRange(r) => Some(r.message().slot()),
+            Self::ExecutionPayloadEnvelopesByRoot(r) => Some(r.message().slot()),
             Self::LightClientBootstrap(r) => Some(r.get_slot()),
             Self::LightClientFinalityUpdate(r) => Some(r.get_attested_header_slot()),
             Self::LightClientOptimisticUpdate(r) => Some(r.get_slot()),
@@ -859,6 +887,13 @@ impl<E: EthSpec> std::fmt::Display for RpcSuccessResponse<E> {
                 write!(
                     f,
                     "ExecutionPayloadEnvelopesByRange: Envelope slot: {}",
+                    envelope.message().slot()
+                )
+            }
+            RpcSuccessResponse::ExecutionPayloadEnvelopesByRoot(envelope) => {
+                write!(
+                    f,
+                    "ExecutionPayloadEnvelopesByRoot: Envelope slot: {}",
                     envelope.message().slot()
                 )
             }

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -267,6 +267,9 @@ pub enum Protocol {
     /// The `ExecutionPayloadEnvelopesByRange` protocol name.
     #[strum(serialize = "execution_payload_envelopes_by_range")]
     ExecutionPayloadEnvelopesByRange,
+    /// The `ExecutionPayloadEnvelopesByRoot` protocol name.
+    #[strum(serialize = "execution_payload_envelopes_by_root")]
+    ExecutionPayloadEnvelopesByRoot,
     /// The `Ping` protocol name.
     Ping,
     /// The `MetaData` protocol name.
@@ -300,6 +303,9 @@ impl Protocol {
             Protocol::ExecutionPayloadEnvelopesByRange => {
                 Some(ResponseTermination::ExecutionPayloadEnvelopesByRange)
             }
+            Protocol::ExecutionPayloadEnvelopesByRoot => {
+                Some(ResponseTermination::ExecutionPayloadEnvelopesByRoot)
+            }
             Protocol::Ping => None,
             Protocol::MetaData => None,
             Protocol::LightClientBootstrap => None,
@@ -331,6 +337,7 @@ pub enum SupportedProtocol {
     DataColumnsByRootV1,
     DataColumnsByRangeV1,
     ExecutionPayloadEnvelopesByRangeV1,
+    ExecutionPayloadEnvelopesByRootV1,
     PingV1,
     MetaDataV1,
     MetaDataV2,
@@ -356,6 +363,7 @@ impl SupportedProtocol {
             SupportedProtocol::DataColumnsByRootV1 => "1",
             SupportedProtocol::DataColumnsByRangeV1 => "1",
             SupportedProtocol::ExecutionPayloadEnvelopesByRangeV1 => "1",
+            SupportedProtocol::ExecutionPayloadEnvelopesByRootV1 => "1",
             SupportedProtocol::PingV1 => "1",
             SupportedProtocol::MetaDataV1 => "1",
             SupportedProtocol::MetaDataV2 => "2",
@@ -382,6 +390,9 @@ impl SupportedProtocol {
             SupportedProtocol::DataColumnsByRangeV1 => Protocol::DataColumnsByRange,
             SupportedProtocol::ExecutionPayloadEnvelopesByRangeV1 => {
                 Protocol::ExecutionPayloadEnvelopesByRange
+            }
+            SupportedProtocol::ExecutionPayloadEnvelopesByRootV1 => {
+                Protocol::ExecutionPayloadEnvelopesByRoot
             }
             SupportedProtocol::PingV1 => Protocol::Ping,
             SupportedProtocol::MetaDataV1 => Protocol::MetaData,
@@ -434,10 +445,16 @@ impl SupportedProtocol {
             ]);
         }
         if fork_context.spec.is_gloas_scheduled() {
-            supported.extend_from_slice(&[ProtocolId::new(
-                SupportedProtocol::ExecutionPayloadEnvelopesByRangeV1,
-                Encoding::SSZSnappy,
-            )]);
+            supported.extend_from_slice(&[
+                ProtocolId::new(
+                    SupportedProtocol::ExecutionPayloadEnvelopesByRangeV1,
+                    Encoding::SSZSnappy,
+                ),
+                ProtocolId::new(
+                    SupportedProtocol::ExecutionPayloadEnvelopesByRootV1,
+                    Encoding::SSZSnappy,
+                ),
+            ]);
         }
         supported
     }
@@ -556,6 +573,9 @@ impl ProtocolId {
                 <ExecutionPayloadEnvelopesByRangeRequest as Encode>::ssz_fixed_len(),
                 <ExecutionPayloadEnvelopesByRangeRequest as Encode>::ssz_fixed_len(),
             ),
+            Protocol::ExecutionPayloadEnvelopesByRoot => {
+                RpcLimits::new(0, spec.max_execution_payload_envelopes_by_root_request)
+            }
             Protocol::Ping => RpcLimits::new(
                 <Ping as Encode>::ssz_fixed_len(),
                 <Ping as Encode>::ssz_fixed_len(),
@@ -595,6 +615,9 @@ impl ProtocolId {
             Protocol::ExecutionPayloadEnvelopesByRange => {
                 rpc_execution_payload_envelope_limits_by_fork::<E>(fork_context.current_fork_name())
             }
+            Protocol::ExecutionPayloadEnvelopesByRoot => {
+                rpc_execution_payload_envelope_limits_by_fork::<E>(fork_context.current_fork_name())
+            }
             Protocol::Ping => RpcLimits::new(
                 <Ping as Encode>::ssz_fixed_len(),
                 <Ping as Encode>::ssz_fixed_len(),
@@ -629,6 +652,7 @@ impl ProtocolId {
             | SupportedProtocol::DataColumnsByRootV1
             | SupportedProtocol::DataColumnsByRangeV1
             | SupportedProtocol::ExecutionPayloadEnvelopesByRangeV1
+            | SupportedProtocol::ExecutionPayloadEnvelopesByRootV1
             | SupportedProtocol::LightClientBootstrapV1
             | SupportedProtocol::LightClientOptimisticUpdateV1
             | SupportedProtocol::LightClientFinalityUpdateV1
@@ -794,6 +818,7 @@ pub enum RequestType<E: EthSpec> {
     DataColumnsByRoot(DataColumnsByRootRequest<E>),
     DataColumnsByRange(DataColumnsByRangeRequest),
     ExecutionPayloadEnvelopesByRange(ExecutionPayloadEnvelopesByRangeRequest),
+    ExecutionPayloadEnvelopesByRoot(ExecutionPayloadEnvelopesByRootRequest),
     LightClientBootstrap(LightClientBootstrapRequest),
     LightClientOptimisticUpdate,
     LightClientFinalityUpdate,
@@ -818,6 +843,7 @@ impl<E: EthSpec> RequestType<E> {
             RequestType::DataColumnsByRoot(req) => req.max_requested() as u64,
             RequestType::DataColumnsByRange(req) => req.max_requested::<E>(),
             RequestType::ExecutionPayloadEnvelopesByRange(req) => req.count,
+            RequestType::ExecutionPayloadEnvelopesByRoot(req) => req.block_roots.len() as u64,
             RequestType::Ping(_) => 1,
             RequestType::MetaData(_) => 1,
             RequestType::LightClientBootstrap(_) => 1,
@@ -849,6 +875,9 @@ impl<E: EthSpec> RequestType<E> {
             RequestType::DataColumnsByRange(_) => SupportedProtocol::DataColumnsByRangeV1,
             RequestType::ExecutionPayloadEnvelopesByRange(_) => {
                 SupportedProtocol::ExecutionPayloadEnvelopesByRangeV1
+            }
+            RequestType::ExecutionPayloadEnvelopesByRoot(_) => {
+                SupportedProtocol::ExecutionPayloadEnvelopesByRootV1
             }
             RequestType::Ping(_) => SupportedProtocol::PingV1,
             RequestType::MetaData(req) => match req {
@@ -883,6 +912,9 @@ impl<E: EthSpec> RequestType<E> {
             RequestType::DataColumnsByRange(_) => ResponseTermination::DataColumnsByRange,
             RequestType::ExecutionPayloadEnvelopesByRange(_) => {
                 ResponseTermination::ExecutionPayloadEnvelopesByRange
+            }
+            RequestType::ExecutionPayloadEnvelopesByRoot(_) => {
+                ResponseTermination::ExecutionPayloadEnvelopesByRoot
             }
             RequestType::Status(_) => unreachable!(),
             RequestType::Goodbye(_) => unreachable!(),
@@ -934,6 +966,10 @@ impl<E: EthSpec> RequestType<E> {
                 SupportedProtocol::ExecutionPayloadEnvelopesByRangeV1,
                 Encoding::SSZSnappy,
             )],
+            RequestType::ExecutionPayloadEnvelopesByRoot(_) => vec![ProtocolId::new(
+                SupportedProtocol::ExecutionPayloadEnvelopesByRootV1,
+                Encoding::SSZSnappy,
+            )],
             RequestType::Ping(_) => vec![ProtocolId::new(
                 SupportedProtocol::PingV1,
                 Encoding::SSZSnappy,
@@ -973,6 +1009,7 @@ impl<E: EthSpec> RequestType<E> {
             RequestType::DataColumnsByRoot(_) => false,
             RequestType::DataColumnsByRange(_) => false,
             RequestType::ExecutionPayloadEnvelopesByRange(_) => false,
+            RequestType::ExecutionPayloadEnvelopesByRoot(_) => false,
             RequestType::Ping(_) => true,
             RequestType::MetaData(_) => true,
             RequestType::LightClientBootstrap(_) => true,
@@ -1088,6 +1125,9 @@ impl<E: EthSpec> std::fmt::Display for RequestType<E> {
             }
             RequestType::ExecutionPayloadEnvelopesByRange(req) => {
                 write!(f, "Execution payload envelopes by range: {:?}", req)
+            }
+            RequestType::ExecutionPayloadEnvelopesByRoot(req) => {
+                write!(f, "Execution payload envelopes by root: {:?}", req)
             }
             RequestType::Ping(ping) => write!(f, "Ping: {}", ping.data),
             RequestType::MetaData(_) => write!(f, "MetaData request"),

--- a/beacon_node/lighthouse_network/src/rpc/rate_limiter.rs
+++ b/beacon_node/lighthouse_network/src/rpc/rate_limiter.rs
@@ -107,6 +107,8 @@ pub struct RPCRateLimiter {
     dcbrange_rl: Limiter<PeerId>,
     /// ExecutionPayloadEnvelopesByRange rate limiter.
     execution_payload_envelopes_by_range_rl: Limiter<PeerId>,
+    /// ExecutionPayloadEnvelopesByRoot rate limiter.
+    execution_payload_envelopes_by_root_rl: Limiter<PeerId>,
     /// LightClientBootstrap rate limiter.
     lc_bootstrap_rl: Limiter<PeerId>,
     /// LightClientOptimisticUpdate rate limiter.
@@ -152,6 +154,8 @@ pub struct RPCRateLimiterBuilder {
     dcbrange_quota: Option<Quota>,
     /// Quota for the ExecutionPayloadEnvelopesByRange protocol.
     execution_payload_envelopes_by_range_quota: Option<Quota>,
+    /// Quota for the ExecutionPayloadEnvelopesByRoot protocol.
+    execution_payload_envelopes_by_root_quota: Option<Quota>,
     /// Quota for the LightClientBootstrap protocol.
     lcbootstrap_quota: Option<Quota>,
     /// Quota for the LightClientOptimisticUpdate protocol.
@@ -179,6 +183,9 @@ impl RPCRateLimiterBuilder {
             Protocol::DataColumnsByRange => self.dcbrange_quota = q,
             Protocol::ExecutionPayloadEnvelopesByRange => {
                 self.execution_payload_envelopes_by_range_quota = q
+            }
+            Protocol::ExecutionPayloadEnvelopesByRoot => {
+                self.execution_payload_envelopes_by_root_quota = q
             }
             Protocol::LightClientBootstrap => self.lcbootstrap_quota = q,
             Protocol::LightClientOptimisticUpdate => self.lc_optimistic_update_quota = q,
@@ -215,6 +222,9 @@ impl RPCRateLimiterBuilder {
         let execution_payload_envelopes_by_range_quota = self
             .execution_payload_envelopes_by_range_quota
             .ok_or("ExecutionPayloadEnvelopesByRange quota not specified")?;
+        let execution_payload_envelopes_by_root_quota = self
+            .execution_payload_envelopes_by_root_quota
+            .ok_or("ExecutionPayloadEnvelopesByRoot quota not specified")?;
 
         let blbrange_quota = self
             .blbrange_quota
@@ -248,6 +258,8 @@ impl RPCRateLimiterBuilder {
         let lc_updates_by_range_rl = Limiter::from_quota(lc_updates_by_range_quota)?;
         let execution_payload_envelopes_by_range_rl =
             Limiter::from_quota(execution_payload_envelopes_by_range_quota)?;
+        let execution_payload_envelopes_by_root_rl =
+            Limiter::from_quota(execution_payload_envelopes_by_root_quota)?;
 
         // check for peers to prune every 30 seconds, starting in 30 seconds
         let prune_every = tokio::time::Duration::from_secs(30);
@@ -272,6 +284,7 @@ impl RPCRateLimiterBuilder {
             lc_finality_update_rl,
             lc_updates_by_range_rl,
             execution_payload_envelopes_by_range_rl,
+            execution_payload_envelopes_by_root_rl,
             init_time: Instant::now(),
             fork_context,
         })
@@ -326,6 +339,7 @@ impl RPCRateLimiter {
             light_client_finality_update_quota,
             light_client_updates_by_range_quota,
             execution_payload_envelopes_by_range_quota,
+            execution_payload_envelopes_by_root_quota,
         } = config;
 
         Self::builder()
@@ -342,6 +356,10 @@ impl RPCRateLimiter {
             .set_quota(
                 Protocol::ExecutionPayloadEnvelopesByRange,
                 execution_payload_envelopes_by_range_quota,
+            )
+            .set_quota(
+                Protocol::ExecutionPayloadEnvelopesByRoot,
+                execution_payload_envelopes_by_root_quota,
             )
             .set_quota(Protocol::LightClientBootstrap, light_client_bootstrap_quota)
             .set_quota(
@@ -392,6 +410,9 @@ impl RPCRateLimiter {
             Protocol::DataColumnsByRange => &mut self.dcbrange_rl,
             Protocol::ExecutionPayloadEnvelopesByRange => {
                 &mut self.execution_payload_envelopes_by_range_rl
+            }
+            Protocol::ExecutionPayloadEnvelopesByRoot => {
+                &mut self.execution_payload_envelopes_by_root_rl
             }
             Protocol::LightClientBootstrap => &mut self.lc_bootstrap_rl,
             Protocol::LightClientOptimisticUpdate => &mut self.lc_optimistic_update_rl,

--- a/beacon_node/lighthouse_network/src/service/api_types.rs
+++ b/beacon_node/lighthouse_network/src/service/api_types.rs
@@ -33,6 +33,8 @@ pub enum SyncRequestId {
     DataColumnsByRange(DataColumnsByRangeRequestId),
     /// Execution payload envelopes by range request
     ExecutionPayloadEnvelopesByRange(ExecutionPayloadEnvelopesByRangeRequestId),
+    /// Execution payload envelopes by root request
+    ExecutionPayloadEnvelopesByRoot(ExecutionPayloadEnvelopesByRootRequestId),
 }
 
 /// Request ID for data_columns_by_root requests. Block lookups do not issue this request directly.
@@ -78,6 +80,12 @@ pub struct ExecutionPayloadEnvelopesByRangeRequestId {
     pub id: Id,
     /// The Id of the overall By Range request for block components.
     pub parent_request_id: ComponentsByRangeRequestId,
+}
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+pub struct ExecutionPayloadEnvelopesByRootRequestId {
+    /// Id to identify this attempt at an execution_payload_envelopes_by_root request
+    pub id: Id,
 }
 
 /// Block components by range request for range sync. Includes an ID for downstream consumers to
@@ -153,6 +161,8 @@ pub enum Response<E: EthSpec> {
     DataColumnsByRoot(Option<Arc<DataColumnSidecar<E>>>),
     /// A response to a ExecutionPayloadEnvelopesByRange request.
     ExecutionPayloadEnvelopesByRange(Option<Arc<SignedExecutionPayloadEnvelope<E>>>),
+    /// A response to a ExecutionPayloadEnvelopesByRoot request.
+    ExecutionPayloadEnvelopesByRoot(Option<Arc<SignedExecutionPayloadEnvelope<E>>>),
     /// A response to a LightClientUpdate request.
     LightClientBootstrap(Arc<LightClientBootstrap<E>>),
     /// A response to a LightClientOptimisticUpdate request.
@@ -198,6 +208,14 @@ impl<E: EthSpec> std::convert::From<Response<E>> for RpcResponse<E> {
                     ResponseTermination::ExecutionPayloadEnvelopesByRange,
                 ),
             },
+            Response::ExecutionPayloadEnvelopesByRoot(r) => match r {
+                Some(envelope) => RpcResponse::Success(
+                    RpcSuccessResponse::ExecutionPayloadEnvelopesByRoot(envelope),
+                ),
+                None => RpcResponse::StreamTermination(
+                    ResponseTermination::ExecutionPayloadEnvelopesByRoot,
+                ),
+            },
             Response::Status(s) => RpcResponse::Success(RpcSuccessResponse::Status(s)),
             Response::LightClientBootstrap(b) => {
                 RpcResponse::Success(RpcSuccessResponse::LightClientBootstrap(b))
@@ -240,6 +258,7 @@ impl_display!(
     id,
     parent_request_id
 );
+impl_display!(ExecutionPayloadEnvelopesByRootRequestId, "{}", id);
 impl_display!(ComponentsByRangeRequestId, "{}/{}", id, requester);
 impl_display!(DataColumnsByRootRequestId, "{}/{}", id, requester);
 impl_display!(SingleLookupReqId, "{}/Lookup/{}", req_id, lookup_id);

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -1580,6 +1580,17 @@ impl<E: EthSpec> Network<E> {
                             request_type,
                         })
                     }
+                    RequestType::ExecutionPayloadEnvelopesByRoot(_) => {
+                        metrics::inc_counter_vec(
+                            &metrics::TOTAL_RPC_REQUESTS,
+                            &["execution_payload_envelopes_by_root"],
+                        );
+                        Some(NetworkEvent::RequestReceived {
+                            peer_id,
+                            inbound_request_id,
+                            request_type,
+                        })
+                    }
                     RequestType::LightClientBootstrap(_) => {
                         metrics::inc_counter_vec(
                             &metrics::TOTAL_RPC_REQUESTS,
@@ -1671,6 +1682,12 @@ impl<E: EthSpec> Network<E> {
                             peer_id,
                             Response::ExecutionPayloadEnvelopesByRange(Some(envelope)),
                         ),
+                    RpcSuccessResponse::ExecutionPayloadEnvelopesByRoot(envelope) => self
+                        .build_response(
+                            id,
+                            peer_id,
+                            Response::ExecutionPayloadEnvelopesByRoot(Some(envelope)),
+                        ),
                     // Should never be reached
                     RpcSuccessResponse::LightClientBootstrap(bootstrap) => {
                         self.build_response(id, peer_id, Response::LightClientBootstrap(bootstrap))
@@ -1702,6 +1719,9 @@ impl<E: EthSpec> Network<E> {
                     ResponseTermination::DataColumnsByRange => Response::DataColumnsByRange(None),
                     ResponseTermination::ExecutionPayloadEnvelopesByRange => {
                         Response::ExecutionPayloadEnvelopesByRange(None)
+                    }
+                    ResponseTermination::ExecutionPayloadEnvelopesByRoot => {
+                        Response::ExecutionPayloadEnvelopesByRoot(None)
                     }
                     ResponseTermination::LightClientUpdatesByRange => {
                         Response::LightClientUpdatesByRange(None)

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -16,7 +16,8 @@ use beacon_processor::{
 use lighthouse_network::rpc::InboundRequestId;
 use lighthouse_network::rpc::methods::{
     BlobsByRangeRequest, BlobsByRootRequest, DataColumnsByRangeRequest, DataColumnsByRootRequest,
-    ExecutionPayloadEnvelopesByRangeRequest, LightClientUpdatesByRangeRequest,
+    ExecutionPayloadEnvelopesByRangeRequest, ExecutionPayloadEnvelopesByRootRequest,
+    LightClientUpdatesByRangeRequest,
 };
 use lighthouse_network::{
     Client, MessageId, NetworkGlobals, PeerId, PubsubMessage,
@@ -679,6 +680,28 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         self.try_send(BeaconWorkEvent {
             drop_during_sync: false,
             work: Work::ExecutionPayloadEnvelopesByRangeRequest(Box::new(process_fn)),
+        })
+    }
+
+    /// Create a new work event to process a `ExecutionPayloadEnvelopesByRoot` request from the RPC network.
+    pub fn send_execution_payload_envelopes_by_root_request(
+        self: &Arc<Self>,
+        peer_id: PeerId,
+        inbound_request_id: InboundRequestId,
+        request: ExecutionPayloadEnvelopesByRootRequest,
+    ) -> Result<(), Error<T::EthSpec>> {
+        let processor = self.clone();
+        let process_fn = move || {
+            processor.handle_execution_payload_envelopes_by_root_request(
+                peer_id,
+                inbound_request_id,
+                request,
+            )
+        };
+
+        self.try_send(BeaconWorkEvent {
+            drop_during_sync: false,
+            work: Work::ExecutionPayloadEnvelopesByRootRequest(Box::new(process_fn)),
         })
     }
 

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -7,7 +7,7 @@ use beacon_chain::{BeaconChainError, BeaconChainTypes, WhenSlotSkipped};
 use itertools::{Itertools, process_results};
 use lighthouse_network::rpc::methods::{
     BlobsByRangeRequest, BlobsByRootRequest, DataColumnsByRangeRequest, DataColumnsByRootRequest,
-    ExecutionPayloadEnvelopesByRangeRequest,
+    ExecutionPayloadEnvelopesByRangeRequest, ExecutionPayloadEnvelopesByRootRequest,
 };
 use lighthouse_network::rpc::*;
 use lighthouse_network::{PeerId, ReportSource, Response, SyncInfo};
@@ -1382,5 +1382,56 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         // 3. Retrieve execution payload envelopes for each block root
         // 4. Stream responses back to peer using send_network_message
         // 5. Handle errors and edge cases (missing envelopes, execution layer issues, etc.)
+    }
+
+    /// Handle a `ExecutionPayloadEnvelopesByRoot` request from the peer.
+    #[instrument(
+        name = "handle_execution_payload_envelopes_by_root_request",
+        parent = None,
+        level = "debug",
+        skip_all,
+        fields(peer_id = %peer_id, client = tracing::field::Empty)
+    )]
+    pub fn handle_execution_payload_envelopes_by_root_request(
+        &self,
+        peer_id: PeerId,
+        inbound_request_id: InboundRequestId,
+        request: ExecutionPayloadEnvelopesByRootRequest,
+    ) {
+        let client = self.network_globals.client(&peer_id);
+        Span::current().record("client", field::display(client.kind));
+
+        self.terminate_response_stream(
+            peer_id,
+            inbound_request_id,
+            self.handle_execution_payload_envelopes_by_root_request_inner(
+                peer_id,
+                inbound_request_id,
+                request,
+            ),
+            Response::ExecutionPayloadEnvelopesByRoot,
+        );
+    }
+
+    /// Handle a `ExecutionPayloadEnvelopesByRoot` request from the peer.
+    fn handle_execution_payload_envelopes_by_root_request_inner(
+        &self,
+        peer_id: PeerId,
+        _inbound_request_id: InboundRequestId,
+        request: ExecutionPayloadEnvelopesByRootRequest,
+    ) -> Result<(), (RpcErrorResponse, &'static str)> {
+        debug!(
+            %peer_id,
+            count = request.block_roots.len(),
+            "Received ExecutionPayloadEnvelopesByRoot Request"
+        );
+
+        todo!("TODO(EIP-7732): Implement execution payload envelope retrieval by block root");
+        // This will likely follow a similar pattern to handle_blobs_by_root_request_inner:
+        // 1. Validate request parameters (block_roots count <= MAX_REQUEST_PAYLOADS)
+        // 2. For each block_root in request.block_roots, retrieve the execution payload envelope from storage
+        // 3. Stream responses back to peer using self.send_response() with Response::ExecutionPayloadEnvelopesByRoot(Some(envelope))
+        // 4. Handle errors and edge cases (missing envelopes, execution layer issues, etc.)
+        // 5. Log results at the end showing peer_id, requested count, and returned count
     }
 }

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -260,6 +260,15 @@ impl<T: BeaconChainTypes> Router<T> {
                             request,
                         ),
                 ),
+            RequestType::ExecutionPayloadEnvelopesByRoot(request) => self
+                .handle_beacon_processor_send_result(
+                    self.network_beacon_processor
+                        .send_execution_payload_envelopes_by_root_request(
+                            peer_id,
+                            inbound_request_id,
+                            request,
+                        ),
+                ),
             RequestType::LightClientBootstrap(request) => self.handle_beacon_processor_send_result(
                 self.network_beacon_processor
                     .send_light_client_bootstrap_request(peer_id, inbound_request_id, request),
@@ -320,6 +329,13 @@ impl<T: BeaconChainTypes> Router<T> {
             }
             Response::ExecutionPayloadEnvelopesByRange(envelope) => {
                 self.on_execution_payload_envelopes_by_range_response(
+                    peer_id,
+                    app_request_id,
+                    envelope,
+                );
+            }
+            Response::ExecutionPayloadEnvelopesByRoot(envelope) => {
+                self.on_execution_payload_envelopes_by_root_response(
                     peer_id,
                     app_request_id,
                     envelope,
@@ -767,6 +783,36 @@ impl<T: BeaconChainTypes> Router<T> {
             }
             AppRequestId::Router => {
                 crit!(%peer_id, "All ExecutionPayloadEnvelopesByRange requests belong to sync");
+                return;
+            }
+            AppRequestId::Internal => unreachable!("Handled internally"),
+        }
+    }
+
+    pub fn on_execution_payload_envelopes_by_root_response(
+        &mut self,
+        peer_id: PeerId,
+        app_request_id: AppRequestId,
+        envelope: Option<Arc<types::SignedExecutionPayloadEnvelope<T::EthSpec>>>,
+    ) {
+        trace!(
+            %peer_id,
+            envelope_present = envelope.is_some(),
+            "Received ExecutionPayloadEnvelopesByRoot Response"
+        );
+
+        // All ExecutionPayloadEnvelopesByRoot requests should belong to sync
+        match app_request_id {
+            AppRequestId::Sync(sync_request_id) => {
+                self.send_to_sync(SyncMessage::RpcExecutionPayloadEnvelope {
+                    sync_request_id,
+                    peer_id,
+                    envelope,
+                    seen_timestamp: timestamp_now(),
+                });
+            }
+            AppRequestId::Router => {
+                crit!(%peer_id, "All ExecutionPayloadEnvelopesByRoot requests belong to sync");
                 return;
             }
             AppRequestId::Internal => unreachable!("Handled internally"),

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -38,8 +38,8 @@ use super::block_lookups::BlockLookups;
 use super::network_context::{
     CustodyByRootResult, RangeBlockComponent, RangeRequestId, RpcEvent, SyncNetworkContext,
 };
-use super::peer_sync_info::{PeerSyncType, remote_sync_type};
-use super::range_sync::{EPOCHS_PER_BATCH, RangeSync, RangeSyncType};
+use super::peer_sync_info::{remote_sync_type, PeerSyncType};
+use super::range_sync::{RangeSync, RangeSyncType, EPOCHS_PER_BATCH};
 use crate::network_beacon_processor::{ChainSegmentProcessId, NetworkBeaconProcessor};
 use crate::service::NetworkMessage;
 use crate::status::ToStatusMessage;
@@ -53,14 +53,15 @@ use beacon_chain::{
     AvailabilityProcessingStatus, BeaconChain, BeaconChainTypes, BlockError, EngineState,
 };
 use futures::StreamExt;
-use lighthouse_network::SyncInfo;
 use lighthouse_network::rpc::RPCError;
 use lighthouse_network::service::api_types::{
     BlobsByRangeRequestId, BlocksByRangeRequestId, ComponentsByRangeRequestId, CustodyRequester,
     DataColumnsByRangeRequestId, DataColumnsByRootRequestId, DataColumnsByRootRequester,
-    ExecutionPayloadEnvelopesByRangeRequestId, Id, SingleLookupReqId, SyncRequestId,
+    ExecutionPayloadEnvelopesByRangeRequestId, ExecutionPayloadEnvelopesByRootRequestId, Id,
+    SingleLookupReqId, SyncRequestId,
 };
 use lighthouse_network::types::{NetworkGlobals, SyncState};
+use lighthouse_network::SyncInfo;
 use lighthouse_network::{PeerAction, PeerId};
 use logging::crit;
 use lru_cache::LRUTimeCache;
@@ -487,6 +488,12 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             }
             SyncRequestId::ExecutionPayloadEnvelopesByRange(req_id) => self
                 .on_execution_payload_envelopes_by_range_response(
+                    req_id,
+                    peer_id,
+                    RpcEvent::RPCError(error),
+                ),
+            SyncRequestId::ExecutionPayloadEnvelopesByRoot(req_id) => self
+                .on_execution_payload_envelopes_by_root_response(
                     req_id,
                     peer_id,
                     RpcEvent::RPCError(error),
@@ -1131,6 +1138,12 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     peer_id,
                     RpcEvent::from_chunk(envelope, seen_timestamp),
                 ),
+            SyncRequestId::ExecutionPayloadEnvelopesByRoot(id) => self
+                .on_execution_payload_envelopes_by_root_response(
+                    id,
+                    peer_id,
+                    RpcEvent::from_chunk(envelope, seen_timestamp),
+                ),
             _ => {
                 crit!(%peer_id, "bad request id for execution payload envelope");
             }
@@ -1144,6 +1157,15 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         _envelope: RpcEvent<Arc<types::SignedExecutionPayloadEnvelope<T::EthSpec>>>,
     ) {
         todo!("TODO(EIP-7732): Handle envelopes for range and backfill sync.")
+    }
+
+    fn on_execution_payload_envelopes_by_root_response(
+        &mut self,
+        _id: ExecutionPayloadEnvelopesByRootRequestId,
+        _peer_id: PeerId,
+        _envelope: RpcEvent<Arc<types::SignedExecutionPayloadEnvelope<T::EthSpec>>>,
+    ) {
+        todo!("TODO(EIP-7732): Handle execution payload envelope by root responses.")
     }
 
     fn on_single_blob_response(

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -267,6 +267,7 @@ pub struct ChainSpec {
     /*
      * Networking Gloas
      */
+    pub max_request_payloads: u64,
 
     /*
      * Networking Derived
@@ -277,6 +278,7 @@ pub struct ChainSpec {
     pub max_blocks_by_root_request_deneb: usize,
     pub max_blobs_by_root_request: usize,
     pub max_data_columns_by_root_request: usize,
+    pub max_execution_payload_envelopes_by_root_request: usize,
 
     /*
      * Application params
@@ -1142,6 +1144,17 @@ impl ChainSpec {
             max_data_columns_by_root_request: default_data_columns_by_root_request(),
 
             /*
+             * Networking Gloas specific
+             */
+            max_request_payloads: default_max_request_payloads(),
+
+            /*
+             * Derived Gloas Specific
+             */
+            max_execution_payload_envelopes_by_root_request:
+                default_max_execution_payload_envelopes_by_root_request(),
+
+            /*
              * Application specific
              */
             domain_application_mask: APPLICATION_DOMAIN_BUILDER,
@@ -1493,6 +1506,17 @@ impl ChainSpec {
             max_data_columns_by_root_request: default_data_columns_by_root_request(),
 
             /*
+             * Networking Gloas specific
+             */
+            max_request_payloads: default_max_request_payloads(),
+
+            /*
+             * Derived Gloas Specific
+             */
+            max_execution_payload_envelopes_by_root_request:
+                default_max_execution_payload_envelopes_by_root_request(),
+
+            /*
              * Application specific
              */
             domain_application_mask: APPLICATION_DOMAIN_BUILDER,
@@ -1816,7 +1840,9 @@ pub struct Config {
     #[serde(default = "default_max_request_blob_sidecars_electra")]
     #[serde(with = "serde_utils::quoted_u64")]
     max_request_blob_sidecars_electra: u64,
-
+    #[serde(default = "default_max_request_payloads")]
+    #[serde(with = "serde_utils::quoted_u64")]
+    max_request_payloads: u64,
     #[serde(default = "default_number_of_custody_groups")]
     #[serde(with = "serde_utils::quoted_u64")]
     number_of_custody_groups: u64,
@@ -1990,6 +2016,10 @@ const fn default_maximum_gossip_clock_disparity_millis() -> u64 {
     500
 }
 
+const fn default_max_request_payloads() -> u64 {
+    128
+}
+
 const fn default_custody_requirement() -> u64 {
     4
 }
@@ -2062,6 +2092,18 @@ fn max_data_columns_by_root_request_common<E: EthSpec>(max_request_blocks: u64) 
     .len()
 }
 
+fn max_execution_payload_envelopes_by_root_request_common(max_request_payloads: u64) -> usize {
+    let max_request_payloads = max_request_payloads as usize;
+
+    RuntimeVariableList::<Hash256>::new(
+        vec![Hash256::zero(); max_request_payloads],
+        max_request_payloads,
+    )
+    .expect("creating a RuntimeVariableList of size `max_request_payloads` should succeed")
+    .as_ssz_bytes()
+    .len()
+}
+
 fn default_max_blocks_by_root_request() -> usize {
     max_blocks_by_root_request_common(default_max_request_blocks())
 }
@@ -2076,6 +2118,10 @@ fn default_max_blobs_by_root_request() -> usize {
 
 fn default_data_columns_by_root_request() -> usize {
     max_data_columns_by_root_request_common::<MainnetEthSpec>(default_max_request_blocks_deneb())
+}
+
+fn default_max_execution_payload_envelopes_by_root_request() -> usize {
+    max_execution_payload_envelopes_by_root_request_common(default_max_request_payloads())
 }
 
 impl Default for Config {
@@ -2231,6 +2277,7 @@ impl Config {
             balance_per_additional_custody_group: spec.balance_per_additional_custody_group,
             min_epochs_for_data_column_sidecars_requests: spec
                 .min_epochs_for_data_column_sidecars_requests,
+            max_request_payloads: spec.max_request_payloads,
         }
     }
 
@@ -2297,6 +2344,7 @@ impl Config {
             max_request_blocks_deneb,
             max_request_blob_sidecars,
             max_request_data_column_sidecars,
+            max_request_payloads,
             min_epochs_for_blob_sidecars_requests,
             blob_sidecar_subnet_count,
             max_blobs_per_block,
@@ -2368,6 +2416,7 @@ impl Config {
             message_domain_valid_snappy,
             attestation_subnet_prefix_bits,
             max_request_blocks,
+            max_request_payloads,
             attestation_propagation_slot_range,
             maximum_gossip_clock_disparity_millis,
             max_request_blocks_deneb,
@@ -2392,6 +2441,8 @@ impl Config {
             max_data_columns_by_root_request: max_data_columns_by_root_request_common::<E>(
                 max_request_blocks_deneb,
             ),
+            max_execution_payload_envelopes_by_root_request:
+                max_execution_payload_envelopes_by_root_request_common(max_request_payloads),
 
             number_of_custody_groups,
             data_column_sidecar_subnet_count,


### PR DESCRIPTION
## Changes
- added boilerplate for `ExecutionPayloadEnvelopesByRoot v1` per [spec](https://ethereum.github.io/consensus-specs/specs/gloas/p2p-interface/#executionpayloadenvelopesbyroot-v1)