### PR TITLE
chore: batched vc voting publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9709,6 +9709,7 @@ dependencies = [
  "bls",
  "eth2",
  "slashing_protection",
+ "tokio",
  "types",
 ]
 

--- a/validator_client/lighthouse_validator_store/src/lib.rs
+++ b/validator_client/lighthouse_validator_store/src/lib.rs
@@ -885,7 +885,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore for LighthouseValidatorS
     async fn sign_attestations(
         self: &Arc<Self>,
         mut attestations: Vec<(u64, PublicKeyBytes, usize, Attestation<Self::E>)>,
-    ) -> Result<Vec<(u64, Attestation<E>)>, Error> {
+    ) -> Result<tokio::sync::mpsc::Receiver<Vec<(u64, Attestation<E>)>>, Error> {
         // Sign all attestations concurrently.
         let signing_futures =
             attestations
@@ -931,8 +931,12 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore for LighthouseValidatorS
             }
         }
 
+        // Wrap result in a channel. For Lighthouse, this is a single batch containing all
+        // attestations, identical in behavior to the previous Vec return type.
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+
         if signed_attestations.is_empty() {
-            return Ok(vec![]);
+            return Ok(rx);
         }
 
         // Check slashing protection and insert into database. Use a dedicated blocking thread
@@ -947,7 +951,10 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore for LighthouseValidatorS
             .ok_or(Error::ExecutorError)?
             .await
             .map_err(|_| Error::ExecutorError)??;
-        Ok(safe_attestations)
+
+        // Send the single batch. If the receiver is already dropped, that's fine.
+        let _ = tx.send(safe_attestations).await;
+        Ok(rx)
     }
 
     async fn sign_validator_registration_data(
@@ -1164,6 +1171,126 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore for LighthouseValidatorS
         );
 
         Ok(SignedContributionAndProof { message, signature })
+    }
+
+    async fn sign_aggregate_and_proofs(
+        self: &Arc<Self>,
+        aggregates: Vec<(PublicKeyBytes, u64, Attestation<E>, SelectionProof)>,
+    ) -> Result<tokio::sync::mpsc::Receiver<Vec<SignedAggregateAndProof<E>>>, Error> {
+        let signing_futures = aggregates.into_iter().map(
+            |(pubkey, aggregator_index, aggregate, selection_proof)| async move {
+                match self
+                    .produce_signed_aggregate_and_proof(
+                        pubkey,
+                        aggregator_index,
+                        aggregate,
+                        selection_proof,
+                    )
+                    .await
+                {
+                    Ok(signed) => Some(signed),
+                    Err(ValidatorStoreError::UnknownPubkey(pubkey)) => {
+                        warn!(
+                            info = "a validator may have recently been removed from this VC",
+                            ?pubkey,
+                            "Missing pubkey for aggregate"
+                        );
+                        None
+                    }
+                    Err(e) => {
+                        crit!(error = ?e, "Failed to sign aggregate");
+                        None
+                    }
+                }
+            },
+        );
+
+        let results: Vec<_> = join_all(signing_futures).await.into_iter().flatten().collect();
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        if !results.is_empty() {
+            let _ = tx.send(results).await;
+        }
+        Ok(rx)
+    }
+
+    async fn sign_sync_committee_signatures(
+        self: &Arc<Self>,
+        messages: Vec<(Slot, Hash256, u64, PublicKeyBytes)>,
+    ) -> Result<tokio::sync::mpsc::Receiver<Vec<SyncCommitteeMessage>>, Error> {
+        let signing_futures = messages.into_iter().map(
+            |(slot, beacon_block_root, validator_index, pubkey)| async move {
+                match self
+                    .produce_sync_committee_signature(
+                        slot,
+                        beacon_block_root,
+                        validator_index,
+                        &pubkey,
+                    )
+                    .await
+                {
+                    Ok(sig) => Some(sig),
+                    Err(ValidatorStoreError::UnknownPubkey(pubkey)) => {
+                        warn!(
+                            info = "a validator may have recently been removed from this VC",
+                            ?pubkey,
+                            "Missing pubkey for sync committee signature"
+                        );
+                        None
+                    }
+                    Err(e) => {
+                        crit!(error = ?e, "Failed to sign sync committee message");
+                        None
+                    }
+                }
+            },
+        );
+
+        let results: Vec<_> = join_all(signing_futures).await.into_iter().flatten().collect();
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        if !results.is_empty() {
+            let _ = tx.send(results).await;
+        }
+        Ok(rx)
+    }
+
+    async fn sign_sync_committee_contributions(
+        self: &Arc<Self>,
+        contributions: Vec<(u64, PublicKeyBytes, SyncCommitteeContribution<E>, SyncSelectionProof)>,
+    ) -> Result<tokio::sync::mpsc::Receiver<Vec<SignedContributionAndProof<E>>>, Error> {
+        let signing_futures = contributions.into_iter().map(
+            |(aggregator_index, aggregator_pubkey, contribution, selection_proof)| async move {
+                match self
+                    .produce_signed_contribution_and_proof(
+                        aggregator_index,
+                        aggregator_pubkey,
+                        contribution,
+                        selection_proof,
+                    )
+                    .await
+                {
+                    Ok(signed) => Some(signed),
+                    Err(ValidatorStoreError::UnknownPubkey(pubkey)) => {
+                        warn!(
+                            info = "a validator may have recently been removed from this VC",
+                            ?pubkey,
+                            "Missing pubkey for sync contribution"
+                        );
+                        None
+                    }
+                    Err(e) => {
+                        crit!(error = ?e, "Failed to sign sync committee contribution");
+                        None
+                    }
+                }
+            },
+        );
+
+        let results: Vec<_> = join_all(signing_futures).await.into_iter().flatten().collect();
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        if !results.is_empty() {
+            let _ = tx.send(results).await;
+        }
+        Ok(rx)
     }
 
     /// Prune the slashing protection database so that it remains performant.

--- a/validator_client/validator_services/src/attestation_service.rs
+++ b/validator_client/validator_services/src/attestation_service.rs
@@ -1,6 +1,5 @@
 use crate::duties_service::{DutiesService, DutyAndProof};
 use beacon_node_fallback::{ApiTopic, BeaconNodeFallback, beacon_head_monitor::HeadEvent};
-use futures::future::join_all;
 use logging::crit;
 use slot_clock::SlotClock;
 use std::collections::HashMap;
@@ -12,8 +11,10 @@ use tokio::sync::mpsc;
 use tokio::time::{Duration, Instant, sleep, sleep_until};
 use tracing::{Instrument, debug, error, info, info_span, instrument, warn};
 use tree_hash::TreeHash;
-use types::{Attestation, AttestationData, ChainSpec, CommitteeIndex, EthSpec, Hash256, Slot};
-use validator_store::{Error as ValidatorStoreError, ValidatorStore};
+use types::{
+    Attestation, AttestationData, ChainSpec, CommitteeIndex, EthSpec, ForkName, Hash256, Slot,
+};
+use validator_store::ValidatorStore;
 
 /// Builds an `AttestationService`.
 #[derive(Default)]
@@ -494,6 +495,10 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
     ///
     /// The given `validator_duties` should already be filtered to only contain those that match
     /// `slot`. Critical errors will be logged if this is not the case.
+    ///
+    /// When `parallel_sign` is true (DVT/distributed mode), attestation batches from the channel
+    /// are published incrementally as each batch arrives. When false (standard mode), all batches
+    /// are collected first and published in a single request.
     #[instrument(skip_all, fields(%slot, %attestation_data.beacon_block_root))]
     async fn sign_and_publish_attestations(
         &self,
@@ -573,29 +578,72 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
             return Ok(());
         }
 
-        // Sign and check all attestations (includes slashing protection).
-        let safe_attestations = self
+        // Sign attestations. Returns a channel that yields batches of signed attestations.
+        // For standard Lighthouse, a single batch is sent. For DVT, multiple batches may
+        // arrive (one per committee) allowing incremental publishing.
+        let mut rx = self
             .validator_store
             .sign_attestations(attestations_to_sign)
             .await
             .map_err(|e| format!("Failed to sign attestations: {e:?}"))?;
 
-        if safe_attestations.is_empty() {
-            warn!("No attestations were published");
-            return Ok(());
-        }
         let fork_name = self
             .chain_spec
             .fork_name_at_slot::<S::E>(attestation_data.slot);
 
-        let single_attestations = safe_attestations
+        if self.duties_service.selection_proof_config.parallel_sign {
+            // Streaming path: publish each batch from the channel as it arrives.
+            // This allows fast committees to be published without waiting for slow ones.
+            while let Some(batch) = rx.recv().await {
+                if !batch.is_empty() {
+                    self.publish_attestation_batch(
+                        &batch,
+                        fork_name,
+                        &attestation_data,
+                        slot,
+                    )
+                    .await;
+                }
+            }
+        } else {
+            // Collect-all path: identical to previous behavior. Collect all batches from
+            // the channel, then publish once.
+            let mut all_attestations = Vec::new();
+            while let Some(batch) = rx.recv().await {
+                all_attestations.extend(batch);
+            }
+            if all_attestations.is_empty() {
+                warn!("No attestations were published");
+                return Ok(());
+            }
+            self.publish_attestation_batch(
+                &all_attestations,
+                fork_name,
+                &attestation_data,
+                slot,
+            )
+            .await;
+        }
+
+        Ok(())
+    }
+
+    /// Publish a batch of signed attestations to the beacon node.
+    ///
+    /// Handles SingleAttestation conversion, BN posting, metrics, and logging.
+    async fn publish_attestation_batch(
+        &self,
+        attestations: &[(u64, Attestation<S::E>)],
+        fork_name: ForkName,
+        attestation_data: &AttestationData,
+        slot: Slot,
+    ) {
+        let single_attestations = attestations
             .iter()
             .filter_map(|(i, a)| {
                 match a.to_single_attestation_with_attester_index(*i) {
                     Ok(a) => Some(a),
                     Err(e) => {
-                        // This shouldn't happen unless BN and VC are out of sync with
-                        // respect to the Electra fork.
                         error!(
                             error = ?e,
                             committee_index = attestation_data.index,
@@ -615,7 +663,6 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
             .collect::<Vec<_>>();
         let published_count = single_attestations.len();
 
-        // Post the attestations to the BN.
         match self
             .beacon_nodes
             .request(ApiTopic::Attestations, |beacon_node| async move {
@@ -651,8 +698,6 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
                 "Unable to publish attestations"
             ),
         }
-
-        Ok(())
     }
 
     /// Performs the second step of the attesting process: downloading an aggregated `Attestation`,
@@ -725,117 +770,120 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
             .await
             .map_err(|e| e.to_string())?;
 
-        // Create futures to produce the signed aggregated attestations.
-        let signing_futures = validator_duties.iter().map(|duty_and_proof| async move {
-            let duty = &duty_and_proof.duty;
-            let selection_proof = duty_and_proof.selection_proof.as_ref()?;
+        // Build the batch of aggregates to sign.
+        let aggregates_to_sign: Vec<_> = validator_duties
+            .iter()
+            .filter_map(|duty_and_proof| {
+                let duty = &duty_and_proof.duty;
+                let selection_proof = duty_and_proof.selection_proof.as_ref()?;
 
-            if !duty.match_attestation_data::<S::E>(attestation_data, &self.chain_spec) {
-                crit!("Inconsistent validator duties during signing");
-                return None;
-            }
+                if !duty.match_attestation_data::<S::E>(attestation_data, &self.chain_spec) {
+                    crit!("Inconsistent validator duties during signing");
+                    return None;
+                }
 
-            match self
-                .validator_store
-                .produce_signed_aggregate_and_proof(
+                Some((
                     duty.pubkey,
                     duty.validator_index,
                     aggregated_attestation.clone(),
                     selection_proof.clone(),
-                )
-                .await
-            {
-                Ok(aggregate) => Some(aggregate),
-                Err(ValidatorStoreError::UnknownPubkey(pubkey)) => {
-                    // A pubkey can be missing when a validator was recently
-                    // removed via the API.
-                    debug!(?pubkey, "Missing pubkey for aggregate");
-                    None
-                }
-                Err(e) => {
-                    crit!(
-                        error = ?e,
-                        pubkey = ?duty.pubkey,
-                        "Failed to sign aggregate"
-                    );
-                    None
+                ))
+            })
+            .collect();
+
+        if aggregates_to_sign.is_empty() {
+            return Ok(());
+        }
+
+        // Sign aggregates. Returns a channel that yields batches of signed aggregates.
+        let mut rx = self
+            .validator_store
+            .sign_aggregate_and_proofs(aggregates_to_sign)
+            .await
+            .map_err(|e| format!("Failed to sign aggregates: {e:?}"))?;
+
+        if self.duties_service.selection_proof_config.parallel_sign {
+            // Streaming path: publish each batch as it arrives.
+            while let Some(batch) = rx.recv().await {
+                if !batch.is_empty() {
+                    self.publish_aggregate_batch(&batch, fork_name).await;
                 }
             }
-        });
-
-        // Execute all the futures in parallel, collecting any successful results.
-        let aggregator_count = validator_duties
-            .iter()
-            .filter(|d| d.selection_proof.is_some())
-            .count();
-        let signed_aggregate_and_proofs = join_all(signing_futures)
-            .instrument(info_span!("sign_aggregates", count = aggregator_count))
-            .await
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
-
-        if !signed_aggregate_and_proofs.is_empty() {
-            let signed_aggregate_and_proofs_slice = signed_aggregate_and_proofs.as_slice();
-            match self
-                .beacon_nodes
-                .first_success(|beacon_node| async move {
-                    let _timer = validator_metrics::start_timer_vec(
-                        &validator_metrics::ATTESTATION_SERVICE_TIMES,
-                        &[validator_metrics::AGGREGATES_HTTP_POST],
-                    );
-                    if fork_name.electra_enabled() {
-                        beacon_node
-                            .post_validator_aggregate_and_proof_v2(
-                                signed_aggregate_and_proofs_slice,
-                                fork_name,
-                            )
-                            .await
-                    } else {
-                        beacon_node
-                            .post_validator_aggregate_and_proof_v1(
-                                signed_aggregate_and_proofs_slice,
-                            )
-                            .await
-                    }
-                })
-                .instrument(info_span!(
-                    "publish_aggregates",
-                    count = signed_aggregate_and_proofs.len()
-                ))
-                .await
-            {
-                Ok(()) => {
-                    for signed_aggregate_and_proof in signed_aggregate_and_proofs {
-                        let attestation = signed_aggregate_and_proof.message().aggregate();
-                        info!(
-                            aggregator = signed_aggregate_and_proof.message().aggregator_index(),
-                            signatures = attestation.num_set_aggregation_bits(),
-                            head_block = format!("{:?}", attestation.data().beacon_block_root),
-                            committee_index = attestation.committee_index(),
-                            slot = attestation.data().slot.as_u64(),
-                            "type" = "aggregated",
-                            "Successfully published attestation"
-                        );
-                    }
-                }
-                Err(e) => {
-                    for signed_aggregate_and_proof in signed_aggregate_and_proofs {
-                        let attestation = &signed_aggregate_and_proof.message().aggregate();
-                        crit!(
-                            error = %e,
-                            aggregator = signed_aggregate_and_proof.message().aggregator_index(),
-                            committee_index = attestation.committee_index(),
-                            slot = attestation.data().slot.as_u64(),
-                            "type" = "aggregated",
-                            "Failed to publish attestation"
-                        );
-                    }
-                }
+        } else {
+            // Collect-all path: identical to previous behavior.
+            let mut all_aggregates = Vec::new();
+            while let Some(batch) = rx.recv().await {
+                all_aggregates.extend(batch);
+            }
+            if !all_aggregates.is_empty() {
+                self.publish_aggregate_batch(&all_aggregates, fork_name)
+                    .await;
             }
         }
 
         Ok(())
+    }
+
+    /// Publish a batch of signed aggregate and proofs to the beacon node.
+    async fn publish_aggregate_batch(
+        &self,
+        signed_aggregate_and_proofs: &[types::SignedAggregateAndProof<S::E>],
+        fork_name: ForkName,
+    ) {
+        match self
+            .beacon_nodes
+            .first_success(|beacon_node| async move {
+                let _timer = validator_metrics::start_timer_vec(
+                    &validator_metrics::ATTESTATION_SERVICE_TIMES,
+                    &[validator_metrics::AGGREGATES_HTTP_POST],
+                );
+                if fork_name.electra_enabled() {
+                    beacon_node
+                        .post_validator_aggregate_and_proof_v2(
+                            signed_aggregate_and_proofs,
+                            fork_name,
+                        )
+                        .await
+                } else {
+                    beacon_node
+                        .post_validator_aggregate_and_proof_v1(signed_aggregate_and_proofs)
+                        .await
+                }
+            })
+            .instrument(info_span!(
+                "publish_aggregates",
+                count = signed_aggregate_and_proofs.len()
+            ))
+            .await
+        {
+            Ok(()) => {
+                for signed_aggregate_and_proof in signed_aggregate_and_proofs {
+                    let attestation = signed_aggregate_and_proof.message().aggregate();
+                    info!(
+                        aggregator = signed_aggregate_and_proof.message().aggregator_index(),
+                        signatures = attestation.num_set_aggregation_bits(),
+                        head_block = format!("{:?}", attestation.data().beacon_block_root),
+                        committee_index = attestation.committee_index(),
+                        slot = attestation.data().slot.as_u64(),
+                        "type" = "aggregated",
+                        "Successfully published attestation"
+                    );
+                }
+            }
+            Err(e) => {
+                for signed_aggregate_and_proof in signed_aggregate_and_proofs {
+                    let attestation = &signed_aggregate_and_proof.message().aggregate();
+                    crit!(
+                        error = %e,
+                        aggregator = signed_aggregate_and_proof.message().aggregator_index(),
+                        committee_index = attestation.committee_index(),
+                        slot = attestation.data().slot.as_u64(),
+                        "type" = "aggregated",
+                        "Failed to publish attestation"
+                    );
+                }
+            }
+        }
     }
 
     /// Spawn a blocking task to run the slashing protection pruning process.

--- a/validator_client/validator_services/src/sync_committee_service.rs
+++ b/validator_client/validator_services/src/sync_committee_service.rs
@@ -3,7 +3,6 @@ use beacon_node_fallback::{ApiTopic, BeaconNodeFallback};
 use bls::PublicKeyBytes;
 use eth2::types::BlockId;
 use futures::future::FutureExt;
-use futures::future::join_all;
 use logging::crit;
 use slot_clock::SlotClock;
 use std::collections::HashMap;
@@ -14,10 +13,10 @@ use task_executor::TaskExecutor;
 use tokio::time::{Duration, Instant, sleep, sleep_until};
 use tracing::{Instrument, debug, error, info, info_span, instrument, trace, warn};
 use types::{
-    ChainSpec, EthSpec, Hash256, Slot, SyncCommitteeSubscription, SyncContributionData, SyncDuty,
-    SyncSelectionProof, SyncSubnetId,
+    ChainSpec, EthSpec, Hash256, Slot, SyncCommitteeMessage, SyncCommitteeSubscription,
+    SyncContributionData, SyncDuty, SyncSelectionProof, SyncSubnetId,
 };
-use validator_store::{Error as ValidatorStoreError, ValidatorStore};
+use validator_store::ValidatorStore;
 
 pub const SUBSCRIPTION_LOOKAHEAD_EPOCHS: u64 = 4;
 
@@ -247,53 +246,60 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
         beacon_block_root: Hash256,
         validator_duties: Vec<SyncDuty>,
     ) -> Result<(), ()> {
-        // Create futures to produce sync committee signatures.
-        let signature_futures = validator_duties.iter().map(|duty| async move {
-            match self
-                .validator_store
-                .produce_sync_committee_signature(
-                    slot,
-                    beacon_block_root,
-                    duty.validator_index,
-                    &duty.pubkey,
-                )
-                .await
-            {
-                Ok(signature) => Some(signature),
-                Err(ValidatorStoreError::UnknownPubkey(pubkey)) => {
-                    // A pubkey can be missing when a validator was recently
-                    // removed via the API.
-                    debug!(
-                        ?pubkey,
-                        validator_index = duty.validator_index,
-                        %slot,
-                        "Missing pubkey for sync committee signature"
-                    );
-                    None
-                }
-                Err(e) => {
-                    crit!(
-                        validator_index = duty.validator_index,
-                        %slot,
-                        error = ?e,
-                        "Failed to sign sync committee signature"
-                    );
-                    None
+        // Build the batch of sync committee messages to sign.
+        let messages_to_sign: Vec<_> = validator_duties
+            .iter()
+            .map(|duty| (slot, beacon_block_root, duty.validator_index, duty.pubkey))
+            .collect();
+
+        if messages_to_sign.is_empty() {
+            return Ok(());
+        }
+
+        // Sign sync committee messages. Returns a channel that yields batches.
+        let mut rx = self
+            .validator_store
+            .sign_sync_committee_signatures(messages_to_sign)
+            .await
+            .map_err(|e| {
+                crit!(%slot, error = ?e, "Failed to sign sync committee signatures");
+            })?;
+
+        if self
+            .duties_service
+            .sync_duties
+            .selection_proof_config
+            .parallel_sign
+        {
+            // Streaming path: publish each batch as it arrives.
+            while let Some(batch) = rx.recv().await {
+                if !batch.is_empty() {
+                    self.publish_sync_signature_batch(&batch, slot, beacon_block_root)
+                        .await?;
                 }
             }
-        });
+        } else {
+            // Collect-all path: identical to previous behavior.
+            let mut all_signatures = Vec::new();
+            while let Some(batch) = rx.recv().await {
+                all_signatures.extend(batch);
+            }
+            if !all_signatures.is_empty() {
+                self.publish_sync_signature_batch(&all_signatures, slot, beacon_block_root)
+                    .await?;
+            }
+        }
 
-        // Execute all the futures in parallel, collecting any successful results.
-        let committee_signatures = &join_all(signature_futures)
-            .instrument(info_span!(
-                "sign_sync_signatures",
-                count = validator_duties.len()
-            ))
-            .await
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
+        Ok(())
+    }
 
+    /// Publish a batch of sync committee signatures to the beacon node.
+    async fn publish_sync_signature_batch(
+        &self,
+        committee_signatures: &[SyncCommitteeMessage],
+        slot: Slot,
+        beacon_block_root: Hash256,
+    ) -> Result<(), ()> {
         self.beacon_nodes
             .request(ApiTopic::SyncCommittee, |beacon_node| async move {
                 beacon_node
@@ -389,51 +395,81 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
             })?
             .data;
 
-        // Create futures to produce signed contributions.
-        let aggregator_count = subnet_aggregators.len();
-        let signature_futures = subnet_aggregators.into_iter().map(
-            |(aggregator_index, aggregator_pk, selection_proof)| async move {
-                match self
-                    .validator_store
-                    .produce_signed_contribution_and_proof(
-                        aggregator_index,
-                        aggregator_pk,
-                        contribution.clone(),
-                        selection_proof,
-                    )
-                    .await
-                {
-                    Ok(signed_contribution) => Some(signed_contribution),
-                    Err(ValidatorStoreError::UnknownPubkey(pubkey)) => {
-                        // A pubkey can be missing when a validator was recently
-                        // removed via the API.
-                        debug!(?pubkey, %slot, "Missing pubkey for sync contribution");
-                        None
-                    }
-                    Err(e) => {
-                        crit!(
-                            %slot,
-                            error = ?e,
-                            "Unable to sign sync committee contribution"
-                        );
-                        None
-                    }
-                }
-            },
-        );
-
-        // Execute all the futures in parallel, collecting any successful results.
-        let signed_contributions = &join_all(signature_futures)
-            .instrument(info_span!(
-                "sign_sync_contributions",
-                count = aggregator_count
-            ))
-            .await
+        // Build the batch of contributions to sign.
+        let contributions_to_sign: Vec<_> = subnet_aggregators
             .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
+            .map(|(aggregator_index, aggregator_pk, selection_proof)| {
+                (
+                    aggregator_index,
+                    aggregator_pk,
+                    contribution.clone(),
+                    selection_proof,
+                )
+            })
+            .collect();
 
-        // Publish to the beacon node.
+        if contributions_to_sign.is_empty() {
+            return Ok(());
+        }
+
+        // Sign contributions. Returns a channel that yields batches.
+        let mut rx = self
+            .validator_store
+            .sign_sync_committee_contributions(contributions_to_sign)
+            .await
+            .map_err(|e| {
+                crit!(%slot, error = ?e, "Failed to sign sync committee contributions");
+            })?;
+
+        if self
+            .duties_service
+            .sync_duties
+            .selection_proof_config
+            .parallel_sign
+        {
+            // Streaming path: publish each batch as it arrives.
+            while let Some(batch) = rx.recv().await {
+                if !batch.is_empty() {
+                    self.publish_sync_contribution_batch(
+                        &batch,
+                        slot,
+                        beacon_block_root,
+                        subnet_id,
+                        contribution.aggregation_bits.num_set_bits(),
+                    )
+                    .await?;
+                }
+            }
+        } else {
+            // Collect-all path: identical to previous behavior.
+            let mut all_contributions = Vec::new();
+            while let Some(batch) = rx.recv().await {
+                all_contributions.extend(batch);
+            }
+            if !all_contributions.is_empty() {
+                self.publish_sync_contribution_batch(
+                    &all_contributions,
+                    slot,
+                    beacon_block_root,
+                    subnet_id,
+                    contribution.aggregation_bits.num_set_bits(),
+                )
+                .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Publish a batch of signed contribution and proofs to the beacon node.
+    async fn publish_sync_contribution_batch(
+        &self,
+        signed_contributions: &[types::SignedContributionAndProof<S::E>],
+        slot: Slot,
+        beacon_block_root: Hash256,
+        subnet_id: SyncSubnetId,
+        num_signers: usize,
+    ) -> Result<(), ()> {
         self.beacon_nodes
             .first_success(|beacon_node| async move {
                 beacon_node
@@ -456,7 +492,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
         info!(
             subnet = %subnet_id,
             beacon_block_root = %beacon_block_root,
-            num_signers = contribution.aggregation_bits.num_set_bits(),
+            num_signers,
             %slot,
             "Successfully published sync contributions"
         );

--- a/validator_client/validator_store/Cargo.toml
+++ b/validator_client/validator_store/Cargo.toml
@@ -8,4 +8,5 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 bls = { workspace = true }
 eth2 = { workspace = true }
 slashing_protection = { workspace = true }
+tokio = { workspace = true }
 types = { workspace = true }

--- a/validator_client/validator_store/src/lib.rs
+++ b/validator_client/validator_store/src/lib.rs
@@ -4,6 +4,7 @@ use slashing_protection::NotSafe;
 use std::fmt::Debug;
 use std::future::Future;
 use std::sync::Arc;
+use tokio::sync::mpsc;
 use types::{
     Address, Attestation, AttestationError, BlindedBeaconBlock, Epoch, EthSpec,
     ExecutionPayloadEnvelope, Graffiti, Hash256, SelectionProof, SignedAggregateAndProof,
@@ -106,22 +107,28 @@ pub trait ValidatorStore: Send + Sync {
 
     /// Sign a batch of `attestations` and apply slashing protection to them.
     ///
-    /// Only successfully signed attestations that pass slashing protection are returned, along with
-    /// the validator index of the signer. Eventually this will be replaced by `SingleAttestation`
-    /// use.
+    /// Returns an `mpsc::Receiver` that yields batches of successfully signed attestations.
+    /// Each batch contains attestations that passed slashing protection, along with the validator
+    /// index of the signer.
+    ///
+    /// For standard (non-distributed) operation, the receiver yields a single batch containing
+    /// all attestations. For DVT/distributed operation, the receiver may yield multiple batches
+    /// (e.g., one per committee) allowing incremental publishing as each committee completes.
     ///
     /// Input:
     ///
     /// * Vec of (validator_index, pubkey, validator_committee_index, attestation).
     ///
-    /// Output:
+    /// Output (per batch):
     ///
     /// * Vec of (validator_index, signed_attestation).
     #[allow(clippy::type_complexity)]
     fn sign_attestations(
         self: &Arc<Self>,
         attestations: Vec<(u64, PublicKeyBytes, usize, Attestation<Self::E>)>,
-    ) -> impl Future<Output = Result<Vec<(u64, Attestation<Self::E>)>, Error<Self::Error>>> + Send;
+    ) -> impl Future<
+        Output = Result<mpsc::Receiver<Vec<(u64, Attestation<Self::E>)>>, Error<Self::Error>>,
+    > + Send;
 
     fn sign_validator_registration_data(
         &self,
@@ -171,6 +178,59 @@ pub trait ValidatorStore: Send + Sync {
         contribution: SyncCommitteeContribution<Self::E>,
         selection_proof: SyncSelectionProof,
     ) -> impl Future<Output = Result<SignedContributionAndProof<Self::E>, Error<Self::Error>>> + Send;
+
+    /// Sign a batch of aggregate and proofs and return results via a channel.
+    ///
+    /// For standard operation, yields a single batch. For DVT, may yield multiple batches
+    /// (e.g., one per committee) for incremental publishing.
+    ///
+    /// Input: Vec of (validator_pubkey, aggregator_index, aggregate_attestation, selection_proof).
+    #[allow(clippy::type_complexity)]
+    fn sign_aggregate_and_proofs(
+        self: &Arc<Self>,
+        aggregates: Vec<(PublicKeyBytes, u64, Attestation<Self::E>, SelectionProof)>,
+    ) -> impl Future<
+        Output = Result<
+            mpsc::Receiver<Vec<SignedAggregateAndProof<Self::E>>>,
+            Error<Self::Error>,
+        >,
+    > + Send;
+
+    /// Sign a batch of sync committee messages and return results via a channel.
+    ///
+    /// For standard operation, yields a single batch. For DVT, may yield multiple batches
+    /// for incremental publishing.
+    ///
+    /// Input: Vec of (slot, beacon_block_root, validator_index, validator_pubkey).
+    #[allow(clippy::type_complexity)]
+    fn sign_sync_committee_signatures(
+        self: &Arc<Self>,
+        messages: Vec<(Slot, Hash256, u64, PublicKeyBytes)>,
+    ) -> impl Future<
+        Output = Result<mpsc::Receiver<Vec<SyncCommitteeMessage>>, Error<Self::Error>>,
+    > + Send;
+
+    /// Sign a batch of sync committee contributions and return results via a channel.
+    ///
+    /// For standard operation, yields a single batch. For DVT, may yield multiple batches
+    /// for incremental publishing.
+    ///
+    /// Input: Vec of (aggregator_index, aggregator_pubkey, contribution, selection_proof).
+    #[allow(clippy::type_complexity)]
+    fn sign_sync_committee_contributions(
+        self: &Arc<Self>,
+        contributions: Vec<(
+            u64,
+            PublicKeyBytes,
+            SyncCommitteeContribution<Self::E>,
+            SyncSelectionProof,
+        )>,
+    ) -> impl Future<
+        Output = Result<
+            mpsc::Receiver<Vec<SignedContributionAndProof<Self::E>>>,
+            Error<Self::Error>,
+        >,
+    > + Send;
 
     /// Prune the slashing protection database so that it remains performant.
     ///


### PR DESCRIPTION
## Proposed Changes

  Changes the `ValidatorStore` batch signing methods to return `mpsc::Receiver<Vec<...>>` instead of `Vec<...>`, allowing results to be published incrementally as each batch completes rather than waiting for all to finish.

  - Modified `sign_attestations` return type to channel-based
  - Added 3 new batch methods: `sign_aggregate_and_proofs`, `sign_sync_committee_signatures`, `sign_sync_committee_contributions`
  - Updated `attestation_service` and `sync_committee_service` to branch on `parallel_sign` -> collect-all for standard mode, streaming publish for DVT mode

  All 4 flows (attestations, aggregates, sync sigs, sync contributions) have the same cross-SSV-committee blocking problem: each validator's signing requires QBFT consensus among its SSV committee operators, and `join_all` + batch publish causes fast committees to wait for slow ones. The batch trait methods let the implementor control batching granularity (e.g., one batch per SSV committee).

  ## Design considerations:                       
                                                                                                 
  1. tokio dep on trait crate -> easily resolved by switching to futures::channel::mpsc
  2. 3 new trait methods -> adds surface area, but all 4 signing flows share the same `batch-then-publish` pattern where incremental delivery is beneficial
  3. Channel overhead in non-distributed mode -> negligible; single send + recv, and the parallel_sign: false path collects everything before publishing (identical to current behavior)
  4. Generality of the abstraction -> channel return type is a generic "streaming results" pattern, not DVT-specific. Standard impl sends 1 batch and drops the sender so zero behavioral change

##  Additional Info

 This is a vibe-coded POC — not intended for merge as-is.  The 3 new batch methods exist so Anchor can control per-SSV-committee batching granularity for all 4 signing flows.